### PR TITLE
chore: migrate toolchain to mise, harden CI, fix docs + JSP cookie bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,42 @@ on:
   pull_request:
     branches: [ master ]
 
+  workflow_call:
+
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  ci:
+
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v3
+        id: filter
+        with:
+          # `base` is ignored on pull_request events (PR base is implicit) and
+          # required for push events / local `act` runs.
+          base: ${{ github.event_name == 'push' && 'master' || '' }}
+          filters: |
+            code:
+              - 'src/**'
+              - 'pom.xml'
+              - 'Makefile'
+              - '.mise.toml'
+              - '.github/workflows/ci.yml'
+
+  build:
+
+    needs: [ changes ]
+    if: ${{ needs.changes.outputs.code == 'true' }}
 
     runs-on: ubuntu-latest
 
@@ -27,39 +54,43 @@ jobs:
         include:
           # Tomcat 9 (javax.servlet, Servlet 4.0) - compiler target 11
           - java: '11'
-            java-distro: 'temurin'
             maven_profile: 'tomcat9'
           - java: '18'
-            java-distro: 'temurin'
             maven_profile: 'tomcat9'
           - java: '25'
-            java-distro: 'temurin'
             maven_profile: 'tomcat9'
-          # Tomcat 10 (jakarta.servlet, Servlet 6.0) - compiler target 17
+          # Tomcat 10 (jakarta.servlet, Servlet 6.1) - compiler target 17
           - java: '18'
-            java-distro: 'temurin'
             maven_profile: 'tomcat10'
           - java: '25'
-            java-distro: 'temurin'
             maven_profile: 'tomcat10'
           # Tomcat 11 (jakarta.servlet, Servlet 6.1) - compiler target 21
           - java: '25'
-            java-distro: 'temurin'
             maven_profile: 'tomcat11'
+
+    env:
+      # Override the .mise.toml java pin per matrix leg (mise resolves the
+      # partial version to the latest Temurin of that major).
+      MISE_JAVA_VERSION: temurin-${{ matrix.java }}
 
     steps:
 
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-    - name: "Set up JDK ${{ matrix.java }} (${{ matrix.java-distro }})"
-      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+    - name: Set up tools (mise)
+      uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
       with:
-        java-version: ${{ matrix.java }}
-        distribution: ${{ matrix.java-distro }}
-        cache: 'maven'
+        install: true
+        # cache disabled: MISE_JAVA_VERSION differs per matrix leg while the
+        # .mise.toml hash (the cache key) is identical across legs.
+        cache: false
 
-    - name: Setup Maven
-      run: make deps-ci
+    - name: Cache Maven repository
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('pom.xml') }}
+        restore-keys: ${{ runner.os }}-maven-
 
     - name: Lint
       run: make lint PROFILE=${{ matrix.maven_profile }}
@@ -69,3 +100,16 @@ jobs:
 
     - name: Test
       run: make test PROFILE=${{ matrix.maven_profile }}
+
+  ci-pass:
+    if: always()
+    needs: [ changes, build ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all jobs passed
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more required jobs failed or were cancelled."
+            exit 1
+          fi
+          echo "All required jobs passed."

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,9 @@
+# Single source of truth for the project toolchain (mise — portfolio policy).
+# Local dev uses the `java` pin below for all profiles (JDK 21 compiles the
+# tomcat9/10/11 source-target levels 11/17/21). CI overrides the JDK per
+# matrix leg via the MISE_JAVA_VERSION env var (see .github/workflows/ci.yml).
+[tools]
+java = "temurin-21.0.11+10.0.LTS"
+maven = "3.9.11"
+node = "24.16.0"
+"aqua:nektos/act" = "0.2.87"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,10 @@ A minimal Java WAR application that replaces Tomcat's default ROOT webapp (`$TOM
 
 ## Build Commands
 
+The toolchain (JDK, Maven, node, act) is managed by [mise](https://mise.jdx.dev/) and pinned in `.mise.toml`. Run `make deps` once to install it (requires mise; `curl https://mise.run | sh`). Local dev builds every profile with the pinned JDK 21; CI tests the real per-JDK matrix.
+
 ```bash
+make deps                        # install the mise-pinned toolchain
 make build                       # Tomcat 9 (default)
 make build PROFILE=tomcat10      # Tomcat 10
 make build PROFILE=tomcat11      # Tomcat 11
@@ -23,18 +26,18 @@ Or with Maven directly:
 
 ```bash
 mvn -B package -Ptomcat9         # Tomcat 9 (default, javax.servlet)
-mvn -B package -Ptomcat10        # Tomcat 10 (jakarta.servlet 6.0)
+mvn -B package -Ptomcat10        # Tomcat 10 (jakarta.servlet 6.1)
 mvn -B package -Ptomcat11        # Tomcat 11 (jakarta.servlet 6.1)
 ```
 
-No test framework is configured — there are no tests to run.
+No test framework is configured — `make test` (and the CI `Test` step) runs `mvn test` against zero tests, so it is currently a no-op placeholder.
 
 ## Maven Profiles
 
 | Profile | Tomcat | Servlet API | source/target | JDK |
 |---------|--------|-------------|---------------|-----|
 | `tomcat9` (default) | 9.0.x | `javax.servlet` 4.0 | 11 | 11-tem |
-| `tomcat10` | 10.1.x | `jakarta.servlet` 6.0 | 17 | 17-tem |
+| `tomcat10` | 10.1.x | `jakarta.servlet` 6.1 | 17 | 17-tem |
 | `tomcat11` | 11.0.x | `jakarta.servlet` 6.1 | 21 | 21-tem |
 
 Properties per profile: `maven.compiler.source`, `maven.compiler.target`, `jdk.version`, `app.sourceDirectory`, `app.webXml`.
@@ -65,17 +68,18 @@ The two `InfoServlet.java` files are identical except for imports (`javax.servle
 
 ## Makefile
 
-The `Makefile` wraps Maven and the scripts. All profile-aware targets accept `PROFILE=tomcat9|tomcat10|tomcat11` (default: `tomcat9`). The `JAVA_VER` is read dynamically from the active profile's `jdk.version` property.
+The `Makefile` wraps Maven and the scripts. All profile-aware targets accept `PROFILE=tomcat9|tomcat10|tomcat11` (default: `tomcat9`). `make deps` installs the mise-pinned toolchain; mise shims are prepended to `PATH` so recipes find the pinned `java`/`mvn`/`act`.
 
 ## CI
 
-GitHub Actions (`ci.yml`) runs on push to `master`, tags `v*`, and pull requests. Matrix strategy tests across:
+GitHub Actions (`ci.yml`) runs on push to `master`, tags `v*`, and pull requests. The toolchain is provided by `jdx/mise-action`; the JDK for each matrix leg is set via the `MISE_JAVA_VERSION` env override. Jobs:
 
-- **Tomcat 9**: JDK 11, 18, 25 (Temurin)
-- **Tomcat 10**: JDK 18, 25 (Temurin)
-- **Tomcat 11**: JDK 25 (Temurin)
-
-Each matrix entry runs `make lint`, `make build`, and `make test`.
+- **changes** — `dorny/paths-filter` detects whether code paths changed (docs-only changes skip the build).
+- **build** — runs `make lint`, `make build`, `make test` across the matrix:
+  - **Tomcat 9**: JDK 11, 18, 25 (Temurin)
+  - **Tomcat 10**: JDK 18, 25 (Temurin)
+  - **Tomcat 11**: JDK 25 (Temurin)
+- **ci-pass** — aggregator gate; the single required status check.
 
 ## Skills
 
@@ -86,6 +90,6 @@ Use the following skills when working on related files:
 | `Makefile` | `/makefile` |
 | `renovate.json` | `/renovate` |
 | `README.md` | `/readme` |
-| `.github/workflows/*.yml` | `/ci-workflow` |
+| `.github/workflows/*.{yml,yaml}` | `/ci-workflow` |
 
 When spawning subagents, always pass conventions from the respective skill into the agent's prompt.

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 .DEFAULT_GOAL := help
 
 SHELL := /bin/bash
-SDKMAN := $(HOME)/.sdkman/bin/sdkman-init.sh
 
-MAVEN_VER := 3.9.11
-ACT_VERSION := 0.2.87
-NVM_VERSION := 0.40.4
+# mise provides the toolchain (java, maven, node, act) — see .mise.toml.
+# Put mise shims on PATH so recipes find mise-installed tools.
+export PATH := $(HOME)/.local/share/mise/shims:$(PATH)
+
 CURRENTTAG := $(shell git describe --tags --abbrev=0 2>/dev/null || echo "dev")
 
 PROFILE ?= tomcat9
@@ -15,9 +15,6 @@ ALLOWED_PROFILES := tomcat9 tomcat10 tomcat11
 ifeq ($(filter $(PROFILE),$(ALLOWED_PROFILES)),)
     $(error Invalid PROFILE=$(PROFILE). Allowed values: $(ALLOWED_PROFILES))
 endif
-
-# Read recommended JDK version from the active Maven profile
-JAVA_VER := $(shell mvn help:evaluate -P$(PROFILE) -Dexpression=jdk.version -q -DforceStdout 2>/dev/null || echo "21-tem")
 
 # Detect macOS for 'open' vs 'xdg-open'
 UNAME_S := $(shell uname -s 2>/dev/null)
@@ -29,30 +26,16 @@ endif
 
 #help: @ List available tasks
 help:
-	@clear
 	@echo "Usage: make COMMAND [PROFILE=tomcat9|tomcat10|tomcat11]"
 	@echo
 	@echo "Commands :"
 	@echo
 	@grep -E '[a-zA-Z\.\-]+:.*?@ .*$$' $(MAKEFILE_LIST)| tr -d '#' | awk 'BEGIN {FS = ":.*?@ "}; {printf "\033[32m%-18s\033[0m - %s\n", $$1, $$2}'
 
-#deps: @ Check required tools are installed
+#deps: @ Install the toolchain (java, maven, node, act) via mise
 deps:
-	@command -v java >/dev/null 2>&1 || { echo "Error: Java required. Install via SDKMAN: https://sdkman.io"; exit 1; }
-	@command -v mvn >/dev/null 2>&1 || { echo "Error: Maven required. Install via SDKMAN: https://sdkman.io"; exit 1; }
-
-#deps-check: @ Install JDK and Maven via SDKMAN
-deps-check:
-	@if [ ! -f "$(SDKMAN)" ]; then \
-		echo "Installing SDKMAN..."; \
-		curl -s "https://get.sdkman.io?rcupdate=false" | bash; \
-	fi
-	@. $(SDKMAN) && echo N | sdk install java $(JAVA_VER) && sdk use java $(JAVA_VER)
-	@. $(SDKMAN) && echo N | sdk install maven $(MAVEN_VER) && sdk use maven $(MAVEN_VER)
-
-#env-check: @ Check installed tools
-env-check: deps-check
-	@printf "\xE2\x9C\x94 sdkman\n"
+	@command -v mise >/dev/null 2>&1 || { echo "Error: mise required. Install: https://mise.jdx.dev (curl https://mise.run | sh)"; exit 1; }
+	@mise install
 
 #clean: @ Cleanup
 clean:
@@ -60,14 +43,14 @@ clean:
 
 #build: @ Build ROOT.war (use PROFILE=tomcat9|tomcat10|tomcat11)
 build: deps
-	@echo "Building with profile: $(PROFILE) (JDK $(JAVA_VER))"
+	@echo "Building with profile: $(PROFILE)"
 	@mvn -B package -P$(PROFILE)
 
 #test: @ Run tests (use PROFILE=tomcat9|tomcat10|tomcat11)
 test: deps
 	@mvn -B test -P$(PROFILE)
 
-#lint: @ Check code style with Maven Checkstyle
+#lint: @ Validate POM and project structure (mvn validate)
 lint: deps
 	@mvn -B validate -P$(PROFILE)
 
@@ -122,40 +105,15 @@ release:
 		git push && \
 		echo "Done."'
 
-#deps-ci: @ Install Maven for CI environments
-deps-ci:
-	@command -v mvn >/dev/null 2>&1 || { \
-		echo "Installing Maven $(MAVEN_VER)..."; \
-		curl -fsSL "https://archive.apache.org/dist/maven/maven-3/$(MAVEN_VER)/binaries/apache-maven-$(MAVEN_VER)-bin.tar.gz" \
-			| sudo tar xz -C /opt; \
-		sudo ln -sf /opt/apache-maven-$(MAVEN_VER)/bin/mvn /usr/local/bin/mvn; \
-	}
-
-#deps-act: @ Install act for local GitHub Actions testing
-deps-act: deps
-	@command -v act >/dev/null 2>&1 || { echo "Installing act $(ACT_VERSION)..."; \
-		curl -sSfL https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash -s -- -b /usr/local/bin v$(ACT_VERSION); \
-	}
-
-#ci-run: @ Run GitHub Actions workflow locally using act
-ci-run: deps-act
+#ci-run: @ Run GitHub Actions workflow locally using act (act installed via mise)
+ci-run: deps
 	@act push --container-architecture linux/amd64 \
 		--artifact-server-path /tmp/act-artifacts
 
-.PHONY: help deps deps-check deps-ci deps-act env-check clean build test lint run ci ci-run \
-	verify-all jetty-run deploy tomcat-install tomcat-switch \
-	deps-print-updates deps-update release renovate-bootstrap renovate-validate
+#renovate-validate: @ Validate Renovate configuration (node provided by mise)
+renovate-validate: deps
+	@npx --yes renovate@latest --platform=local
 
-#renovate-bootstrap: @ Install nvm and npm for Renovate
-renovate-bootstrap:
-	@command -v node >/dev/null 2>&1 || { \
-		echo "Installing nvm $(NVM_VERSION)..."; \
-		curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v$(NVM_VERSION)/install.sh | bash; \
-		export NVM_DIR="$$HOME/.nvm"; \
-		[ -s "$$NVM_DIR/nvm.sh" ] && . "$$NVM_DIR/nvm.sh"; \
-		nvm install --lts; \
-	}
-
-#renovate-validate: @ Validate Renovate configuration
-renovate-validate: renovate-bootstrap
-	@npx --yes renovate --platform=local
+.PHONY: help deps clean build test lint run ci ci-run verify-all jetty-run \
+	deploy tomcat-install tomcat-switch deps-print-updates deps-update \
+	release renovate-validate

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Supports **Tomcat 9**, **10**, and **11** via Maven profiles.
 ## Quick Start
 
 ```bash
-make deps-check    # install JDK and Maven via SDKMAN
+make deps          # install the toolchain (JDK, Maven, node, act) via mise
 make build         # build ROOT.war (Tomcat 9 by default)
 make jetty-run     # run locally with embedded Jetty
 # open http://localhost:8080/
@@ -20,18 +20,21 @@ make jetty-run     # run locally with embedded Jetty
 
 ## Prerequisites
 
+The toolchain (JDK, Maven, node, act) is managed by [mise](https://mise.jdx.dev/) and pinned in [`.mise.toml`](.mise.toml). Install mise once, then `make deps` installs everything else.
+
 | Tool | Version | Purpose |
 |------|---------|---------|
 | [GNU Make](https://www.gnu.org/software/make/) | 3.81+ | Build orchestration |
-| [SDKMAN](https://sdkman.io/) | latest | Java/Maven version management |
-| [JDK](https://adoptium.net/) | 11+ | Java runtime and compiler (installed via SDKMAN) |
-| [Maven](https://maven.apache.org/) | 3.9+ | Build and dependency management (installed via SDKMAN) |
-| [act](https://github.com/nektos/act) | latest | Local GitHub Actions testing (optional) |
+| [mise](https://mise.jdx.dev/) | latest | Toolchain version manager (provides JDK, Maven, node, act) |
+| [JDK](https://adoptium.net/) | 11/17/21 | Java runtime and compiler (provided by mise; local dev uses JDK 21) |
+| [Maven](https://maven.apache.org/) | 3.9+ | Build and dependency management (provided by mise) |
+| [act](https://github.com/nektos/act) | pinned | Local GitHub Actions testing (provided by mise, optional) |
 
-Install all required dependencies:
+Install mise (see the [mise docs](https://mise.jdx.dev/getting-started.html)), then install all pinned tools:
 
 ```bash
-make deps-check
+curl https://mise.run | sh   # one-time mise install
+make deps                    # install JDK, Maven, node, act from .mise.toml
 ```
 
 ## Build Profiles
@@ -41,7 +44,7 @@ Each profile targets a specific Tomcat version with the appropriate Servlet API:
 | Profile | Tomcat | Servlet API | Java | JDK |
 |---------|--------|-------------|------|-----|
 | `tomcat9` (default) | 9.0.x | `javax.servlet` 4.0 | 11 | 11-tem |
-| `tomcat10` | 10.1.x | `jakarta.servlet` 6.0 | 17 | 17-tem |
+| `tomcat10` | 10.1.x | `jakarta.servlet` 6.1 | 17 | 17-tem |
 | `tomcat11` | 11.0.x | `jakarta.servlet` 6.1 | 21 | 21-tem |
 
 Select a profile with `PROFILE=`:
@@ -61,8 +64,8 @@ Run `make help` to see all available targets.
 | Target | Description |
 |--------|-------------|
 | `make build` | Build ROOT.war (use PROFILE=tomcat9\|tomcat10\|tomcat11) |
-| `make test` | Run tests (use PROFILE=tomcat9\|tomcat10\|tomcat11) |
-| `make lint` | Check code style with Maven Checkstyle |
+| `make test` | Run tests &mdash; no test suite is configured yet, so this is currently a no-op (use PROFILE=tomcat9\|tomcat10\|tomcat11) |
+| `make lint` | Validate POM and project structure (`mvn validate`) |
 | `make clean` | Cleanup build artifacts |
 | `make run` | Run locally with Jetty (alias for jetty-run) |
 | `make jetty-run` | Run locally with embedded Jetty server |
@@ -87,14 +90,9 @@ Run `make help` to see all available targets.
 
 | Target | Description |
 |--------|-------------|
-| `make deps` | Check required tools are installed |
-| `make deps-check` | Install JDK and Maven via SDKMAN |
-| `make deps-ci` | Install Maven for CI environments |
-| `make deps-act` | Install act for local GitHub Actions testing |
+| `make deps` | Install the toolchain (JDK, Maven, node, act) via mise |
 | `make deps-print-updates` | Print project dependency updates |
 | `make deps-update` | Update dependencies to latest releases |
-| `make env-check` | Check installed tools |
-| `make renovate-bootstrap` | Install nvm and npm for Renovate |
 | `make renovate-validate` | Validate Renovate configuration |
 | `make release` | Create and push a new tag |
 
@@ -214,27 +212,33 @@ jar tf ./target/ROOT.war
 
 GitHub Actions runs on every push to `master`, tags `v*`, and pull requests.
 
-| Job | Triggers | Steps |
-|-----|----------|-------|
-| **ci** | push (master, tags), PR | Lint, Build, Test |
+| Job | Triggers | Purpose |
+|-----|----------|---------|
+| **changes** | push (master, tags), PR | Detect whether code paths changed (skips the build on docs-only changes) |
+| **build** | when `changes` reports code | Lint, Build, Test across the JDK × Tomcat matrix |
+| **ci-pass** | always | Aggregator gate — the single required status check |
 
-The CI job uses a matrix strategy testing across JDK 11/18/25 with Tomcat 9, JDK 18/25 with Tomcat 10, and JDK 25 with Tomcat 11.
+The **build** job uses a matrix strategy testing across JDK 11/18/25 with Tomcat 9, JDK 18/25 with Tomcat 10, and JDK 25 with Tomcat 11. The JDK for each leg is provided by [mise](https://mise.jdx.dev/) via the `MISE_JAVA_VERSION` override.
 
-[Renovate](https://docs.renovatebot.com/) keeps dependencies up to date with platform automerge enabled.
+[Renovate](https://docs.renovatebot.com/) keeps dependencies up to date with PR automerge enabled (gated on the `ci-pass` check).
 
 ## Screenshots
 
 Default welcome page &mdash; [http://localhost:8080/](http://localhost:8080/)
-![index.html](images/http-8080-root.png)
+
+<img src="images/http-8080-root.png" alt="index.html" width="800">
 
 JSP &mdash; [http://localhost:8080/index.jsp](http://localhost:8080/index.jsp)
-![index.jsp](images/http-8080-index-jsp.png)
+
+<img src="images/http-8080-index-jsp.png" alt="index.jsp" width="800">
 
 Servlet &mdash; [http://localhost:8080/infoservlet](http://localhost:8080/infoservlet)
-![infoservlet](images/http-8080-infoservlet.png)
+
+<img src="images/http-8080-infoservlet.png" alt="infoservlet" width="800">
 
 HTML &mdash; [http://localhost:8080/index.html](http://localhost:8080/index.html)
-![index.html](images/http-8080-index-html.png)
+
+<img src="images/http-8080-index-html.png" alt="index.html" width="800">
 
 ## Used In
 

--- a/renovate.json
+++ b/renovate.json
@@ -12,13 +12,14 @@
   ],
   "enabledManagers": [
     "maven",
-    "github-actions"
+    "github-actions",
+    "mise"
   ],
   "prConcurrentLimit": 50,
   "prHourlyLimit": 0,
   "platformAutomerge": true,
   "automerge": true,
-  "automergeType": "branch",
+  "automergeType": "pr",
   "automergeStrategy": "squash",
   "ignoreTests": false,
   "vulnerabilityAlerts": {

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -80,14 +80,10 @@
     <%
 
         Cookie[] arr1 = request.getCookies();
-        String cookiename = "";
-        String cookievalue ="";
         if ((arr1 != null) && (arr1.length > 0))  {
         for (int i = 0; i < arr1.length; i++) {
-            cookiename = arr1[i].getName();
-            cookievalue = arr1[i].getValue();
-        }
-
+            String cookiename = arr1[i].getName();
+            String cookievalue = arr1[i].getValue();
     %>
     <tr>
         <td>
@@ -97,7 +93,10 @@
             <%=cookievalue %>
         </td>
     </tr>
-    <% } %>
+    <%
+        }
+        }
+    %>
 </table>
 
 


### PR DESCRIPTION
Project-review remediation — Phase A (foundation) + Phase B (docs), all validated locally.

## Foundation (Phase A)
- **`.mise.toml`** (new) — pins `java` (temurin-21), `maven` 3.9.11, `node` 24.16.0, `aqua:nektos/act` 0.2.87 as the single toolchain source (portfolio mise policy).
- **Makefile** — full mise migration: `deps` → `mise install`; removed SDKMAN/nvm/`sudo`/`curl-install` targets (`deps-check`, `env-check`, `deps-ci`, `deps-act`, `renovate-bootstrap`); added mise-shims `PATH` export; removed `@clear`; `.PHONY` to end; honest `lint` description; `renovate-validate` → `renovate@latest` via mise node.
- **ci.yml** — `jdx/mise-action` + per-matrix-leg `MISE_JAVA_VERSION` override (replaces `setup-java`/`make deps-ci`); added `ci-pass` aggregator + `changes` path-filter (`dorny/paths-filter`, SHA-pinned) + `pull-requests: read`; job `ci`→`build`; `~/.m2` cache; `workflow_call:` trigger.
- **renovate.json** — `automergeType: branch` → `pr`; enabled `mise` manager.

## Docs (Phase B, re-derived from post-Phase-A state)
- **README / CLAUDE.md** — mise prerequisites; removed references to deleted targets; **fixed tomcat10 Servlet API `6.0` → `6.1`** (pom declares 6.1.0); rewrote CI section; sized screenshots; `make test` no-op noted; Skills glob `*.yml` → `*.{yml,yaml}`.

## Fix
- **`index.jsp`** — cookie loop now renders **all** cookies (the `<tr>` was outside the `for`, so only the last cookie displayed).

## Validation
- `make verify-all` (all 3 profiles compile under mise) ✓
- `make ci` (deps→clean→lint→build→test) → exit 0 ✓
- `actionlint ci.yml` clean ✓ · `make renovate-validate` exit 0, `mise` manager recognized ✓

## ⚠️ Manual follow-up
`automergeType: pr` is only safe behind a **required status check** — add **`ci-pass`** as the required check on `master` after merge.

## Not included (deferred)
- Security gate (`trivy-fs`/`cve-check`/Checkstyle, real `static-check`) — MEDIUM, separate PR.
- Test coverage (JUnit5+Mockito servlet test + Jetty curl-smoke) — run `/test-coverage-analysis`.