### PR TITLE
chore: upgrade toolchain, jetty-ee10 plugin, and pinned actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v3
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           # `base` is ignored on pull_request events (PR base is implicit) and
@@ -50,7 +50,7 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
     - name: Set up tools (mise)
       uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
@@ -95,7 +95,7 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
     - name: Set up tools (mise)
       uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
@@ -106,7 +106,7 @@ jobs:
         cache: false
 
     - name: Cache Maven repository
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('pom.xml') }}

--- a/.mise.toml
+++ b/.mise.toml
@@ -4,8 +4,8 @@
 # matrix leg via the MISE_JAVA_VERSION env var (see .github/workflows/ci.yml).
 [tools]
 java = "temurin-21.0.11+10.0.LTS"
-maven = "3.9.11"
+maven = "3.9.16"
 node = "24.16.0"
-"aqua:nektos/act" = "0.2.87"
+"aqua:nektos/act" = "0.2.89"
 "aqua:aquasecurity/trivy" = "0.71.1"
 "aqua:gitleaks/gitleaks" = "8.30.1"

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
                     <plugin>
                         <groupId>org.eclipse.jetty.ee10</groupId>
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
-                        <version>12.1.8</version>
+                        <version>12.1.10</version>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Fact-checked upgrade sweep (/upgrade-analysis). Real upgrades only, each verified against its authoritative source.

## Applied
| Item | From | To | Source |
|------|------|----|--------|
| maven (.mise.toml) | 3.9.11 | 3.9.16 | mise ls-remote |
| act (.mise.toml) | 0.2.87 | 0.2.89 | mise ls-remote |
| jetty-ee10-maven-plugin (tomcat11) | 12.1.8 | 12.1.10 | Maven Central metadata |
| actions/checkout | v6 (de0fac2) | v6.0.3 | GitHub |
| dorny/paths-filter | v3 | v4.0.1 | GitHub |
| actions/cache | v4 | v5.0.5 | GitHub |

The two **major** action bumps are safe — release notes confirm both are pure **Node 20→24 runtime** upgrades with no input/output/API changes; GitHub-hosted `ubuntu-latest` exceeds cache v5's runner-version floor (2.327.1).

## Left unchanged (fact-checked reasons)
- **Already latest-stable**: java 21.0.11, node 24.16.0, trivy 0.71.1, gitleaks 8.30.1, maven-war-plugin 3.5.1, jakarta.servlet.jsp.jstl 3.0.1, jetty 9.4.58 / 11.0.26.
- **jakarta.servlet-api 6.1.0** — latest is 6.2.0-**M2** (milestone, not stable); 6.1 is the Servlet spec tied to Tomcat 10/11.
- **javax.servlet-api 4.0.1 + jstl 1.2** — final javax releases, tied to Tomcat 9.

## Verification
- `mvn -v` → 3.9.16 · `make verify-all` → all 3 profiles compile (incl jetty-ee10 12.1.10)
- `make static-check` → exit 0 · `actionlint` → clean