### PR TITLE
feat: add JUnit 5 + Mockito unit tests for InfoServlet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ mvn -B package -Ptomcat10        # Tomcat 10 (jakarta.servlet 6.1)
 mvn -B package -Ptomcat11        # Tomcat 11 (jakarta.servlet 6.1)
 ```
 
-No test framework is configured — `make test` (and the CI `Test` step) runs `mvn test` against zero tests, so it is currently a no-op placeholder.
+Unit tests use **JUnit 5 + Mockito** (run via Surefire). Test sources are profile-specific, mirroring the main sources: `src/test/java` (javax, tomcat9) and `src/test/java-jakarta` (jakarta, tomcat10/11). `make test PROFILE=...` compiles and runs the matching set.
 
 ## Maven Profiles
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Run `make help` to see all available targets.
 | Target | Description |
 |--------|-------------|
 | `make build` | Build ROOT.war (use PROFILE=tomcat9\|tomcat10\|tomcat11) |
-| `make test` | Run tests &mdash; no test suite is configured yet, so this is currently a no-op (use PROFILE=tomcat9\|tomcat10\|tomcat11) |
+| `make test` | Run the JUnit 5 + Mockito unit tests (use PROFILE=tomcat9\|tomcat10\|tomcat11) |
 | `make lint` | Validate POM and project structure (`mvn validate`) |
 | `make clean` | Cleanup build artifacts |
 | `make run` | Run locally with Jetty (alias for jetty-run) |

--- a/pom.xml
+++ b/pom.xml
@@ -14,13 +14,55 @@
         <maven.compiler.target>11</maven.compiler.target>
         <jdk.version>11-tem</jdk.version>
         <app.sourceDirectory>src/main/java</app.sourceDirectory>
+        <app.testSourceDirectory>src/test/java</app.testSourceDirectory>
         <app.webXml>src/main/webapp/WEB-INF/web.xml</app.webXml>
+        <junit.version>5.14.4</junit.version>
+        <mockito.version>5.23.0</mockito.version>
     </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
     <build>
         <finalName>ROOT</finalName>
         <sourceDirectory>${app.sourceDirectory}</sourceDirectory>
+        <testSourceDirectory>${app.testSourceDirectory}</testSourceDirectory>
         <plugins>
+            <!-- Resolve mockito-core's jar path into a property so Surefire can
+                 load it as an explicit -javaagent (avoids the JDK 21+ "Dynamic
+                 loading of agents will be disallowed" self-attach warning). -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.11.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.6</version>
+                <configuration>
+                    <argLine>-javaagent:${org.mockito:mockito-core:jar}</argLine>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
@@ -33,6 +75,8 @@
                             <targetPath>WEB-INF</targetPath>
                             <excludes>
                                 <exclude>maven-status/</exclude>
+                                <exclude>test-classes/</exclude>
+                                <exclude>surefire-reports/</exclude>
                             </excludes>
                         </resource>
                     </webResources>
@@ -87,6 +131,7 @@
                 <maven.compiler.target>17</maven.compiler.target>
                 <jdk.version>17-tem</jdk.version>
                 <app.sourceDirectory>src/main/java-jakarta</app.sourceDirectory>
+                <app.testSourceDirectory>src/test/java-jakarta</app.testSourceDirectory>
                 <app.webXml>src/main/webapp/WEB-INF/web-jakarta.xml</app.webXml>
             </properties>
             <dependencies>
@@ -122,6 +167,7 @@
                 <maven.compiler.target>21</maven.compiler.target>
                 <jdk.version>21-tem</jdk.version>
                 <app.sourceDirectory>src/main/java-jakarta</app.sourceDirectory>
+                <app.testSourceDirectory>src/test/java-jakarta</app.testSourceDirectory>
                 <app.webXml>src/main/webapp/WEB-INF/web-jakarta.xml</app.webXml>
             </properties>
             <dependencies>

--- a/src/test/java-jakarta/com/ak/servlet/InfoServletTest.java
+++ b/src/test/java-jakarta/com/ak/servlet/InfoServletTest.java
@@ -1,0 +1,43 @@
+package com.ak.servlet;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import org.junit.jupiter.api.Test;
+
+class InfoServletTest {
+
+    @Test
+    void doGet_setsHtmlContentType_andForwardsToIndexJsp() throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        RequestDispatcher dispatcher = mock(RequestDispatcher.class);
+        when(response.getWriter()).thenReturn(new PrintWriter(new StringWriter()));
+        when(request.getRequestDispatcher("index.jsp")).thenReturn(dispatcher);
+
+        new InfoServlet().doGet(request, response);
+
+        verify(response).setContentType("text/html;charset=UTF-8");
+        verify(request).getRequestDispatcher("index.jsp");
+        verify(dispatcher).forward(request, response);
+    }
+
+    @Test
+    void doPost_forwardsToIndexJsp() throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        RequestDispatcher dispatcher = mock(RequestDispatcher.class);
+        when(response.getWriter()).thenReturn(new PrintWriter(new StringWriter()));
+        when(request.getRequestDispatcher("index.jsp")).thenReturn(dispatcher);
+
+        new InfoServlet().doPost(request, response);
+
+        verify(dispatcher).forward(request, response);
+    }
+}

--- a/src/test/java/com/ak/servlet/InfoServletTest.java
+++ b/src/test/java/com/ak/servlet/InfoServletTest.java
@@ -1,0 +1,43 @@
+package com.ak.servlet;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+
+class InfoServletTest {
+
+    @Test
+    void doGet_setsHtmlContentType_andForwardsToIndexJsp() throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        RequestDispatcher dispatcher = mock(RequestDispatcher.class);
+        when(response.getWriter()).thenReturn(new PrintWriter(new StringWriter()));
+        when(request.getRequestDispatcher("index.jsp")).thenReturn(dispatcher);
+
+        new InfoServlet().doGet(request, response);
+
+        verify(response).setContentType("text/html;charset=UTF-8");
+        verify(request).getRequestDispatcher("index.jsp");
+        verify(dispatcher).forward(request, response);
+    }
+
+    @Test
+    void doPost_forwardsToIndexJsp() throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        RequestDispatcher dispatcher = mock(RequestDispatcher.class);
+        when(response.getWriter()).thenReturn(new PrintWriter(new StringWriter()));
+        when(request.getRequestDispatcher("index.jsp")).thenReturn(dispatcher);
+
+        new InfoServlet().doPost(request, response);
+
+        verify(dispatcher).forward(request, response);
+    }
+}


### PR DESCRIPTION
Follow-up to #71 — makes `make test` real (was a no-op), the deferred test-coverage finding.

## Changes
- **pom.xml** — `junit-jupiter` 5.14.4 + `mockito-core` 5.23.0 (test scope), `maven-surefire-plugin` 3.5.6. Profile-specific `testSourceDirectory` mirroring the main sources: `src/test/java` (javax/tomcat9), `src/test/java-jakarta` (jakarta/tomcat10/11).
- **Tests** — `InfoServletTest` (both variants): assert `doGet`/`doPost` set `text/html;charset=UTF-8` and forward to `index.jsp`.
- **WAR hygiene** — exclude `test-classes/` + `surefire-reports/` from the WAR (the pre-existing war-plugin webResource copies all of `target/`, which would otherwise leak test artifacts into `ROOT.war`).
- **Zero-warning** — load `mockito-core` as an explicit `-javaagent` via `maven-dependency-plugin` 3.11.0 (`properties` goal) → silences the JDK 21+ "Dynamic loading of agents will be disallowed" self-attach warning.
- **Docs** — README/CLAUDE.md updated (no longer "no tests configured").

## Version choices (fact-checked)
- **JUnit 5.14.4, not 6.x** — JUnit 6 requires Java 17, which would break the JDK 11 (tomcat9) matrix leg. 5.x has a Java 8 floor.
- **Mockito 5.23.0** — Java 11 floor, matches the lowest leg.
- **Surefire 3.5.6** — 3.6.0-M1 is a milestone.

## Verification
- 2 tests pass on **all 3 profiles** and across the **JDK matrix bounds (11 and 25)**.
- `make ci` green · WAR verified free of test artifacts · zero warnings on JDK 25.