### PR TITLE
chore: upgrade sweep — release compile gate, Tomcat bumps, CI/Renovate hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,10 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      code: ${{ steps.filter.outputs.code }}
+      # Tag pushes always run the full pipeline: the tag SHA usually equals
+      # master HEAD, so paths-filter (base: master) would see an empty diff and
+      # skip every gated job, silently leaving a tagged release un-verified.
+      code: ${{ startsWith(github.ref, 'refs/tags/') && 'true' || steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
@@ -40,6 +43,9 @@ jobs:
               - 'Makefile'
               - '.mise.toml'
               - '.github/workflows/ci.yml'
+              # CLAUDE.md is project config (build conventions / skill mappings),
+              # not docs — its edits MUST run CI (/ci-workflow §15c).
+              - 'CLAUDE.md'
 
   static-check:
 

--- a/.github/workflows/cleanup-runs.yml
+++ b/.github/workflows/cleanup-runs.yml
@@ -4,12 +4,18 @@ on:
   schedule:
     - cron: '0 0 * * 0'
   workflow_dispatch:
+  workflow_call:
+
+concurrency:
+  group: cleanup-${{ github.workflow }}
+  cancel-in-progress: true
 
 permissions:
+  contents: read
   actions: write
 
 jobs:
-  cleanup:
+  cleanup-runs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
@@ -19,8 +25,40 @@ jobs:
     steps:
       - name: Delete old workflow runs
         run: |
-          CUTOFF=$(date -u -d "$RETAIN_DAYS days ago" +%Y-%m-%dT%H:%M:%SZ)
+          CUTOFF=$(date -u -d "${RETAIN_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ)
+          # Retain the newest KEEP_MINIMUM runs PER WORKFLOW (group_by
+          # .workflowName), THEN delete any remaining run older than CUTOFF.
+          # A single GLOBAL minimum can purge every run of a low-frequency
+          # workflow and flip it to `state: deleted` (deregistered).
           gh run list --repo "${{ github.repository }}" \
-            --json databaseId,createdAt --limit 200 \
-            --jq "sort_by(.createdAt) | reverse | .[$KEEP_MINIMUM:] | .[] | select(.createdAt < \\"$CUTOFF\\") | .databaseId" \
+            --json databaseId,createdAt,workflowName --limit 300 \
+          | jq -r --arg cutoff "$CUTOFF" --argjson keep "$KEEP_MINIMUM" '
+              group_by(.workflowName)
+              | map(sort_by(.createdAt) | reverse | .[$keep:])
+              | add // []
+              | .[] | select(.createdAt < $cutoff) | .databaseId
+            ' \
           | xargs -r -I{} gh run delete {} --repo "${{ github.repository }}"
+
+  cleanup-caches:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Delete caches from merged/deleted branches
+        run: |
+          echo "=== Cleaning caches from non-existent branches ==="
+          gh cache list --repo "${{ github.repository }}" --json id,ref,key --limit 200 \
+          | jq -r '.[] | "\(.id)\t\(.ref)\t\(.key)"' \
+          | while IFS=$'\t' read -r id ref key; do
+              branch="${ref#refs/heads/}"
+              # Keep caches for master, default branch, and tags
+              if [ "$branch" = "master" ] || [[ "$ref" == refs/tags/* ]]; then
+                continue
+              fi
+              if ! gh api "repos/${{ github.repository }}/branches/${branch}" --silent 2>/dev/null; then
+                echo "Deleting cache ${key} (branch ${branch} no longer exists)"
+                gh cache delete "$id" --repo "${{ github.repository }}" 2>/dev/null || true
+              fi
+            done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,13 +34,13 @@ Unit tests use **JUnit 5 + Mockito** (run via Surefire). Test sources are profil
 
 ## Maven Profiles
 
-| Profile | Tomcat | Servlet API | source/target | JDK |
-|---------|--------|-------------|---------------|-----|
+| Profile | Tomcat | Servlet API | `release` | JDK |
+|---------|--------|-------------|-----------|-----|
 | `tomcat9` (default) | 9.0.x | `javax.servlet` 4.0 | 11 | 11-tem |
 | `tomcat10` | 10.1.x | `jakarta.servlet` 6.1 | 17 | 17-tem |
 | `tomcat11` | 11.0.x | `jakarta.servlet` 6.1 | 21 | 21-tem |
 
-Properties per profile: `maven.compiler.source`, `maven.compiler.target`, `jdk.version`, `app.sourceDirectory`, `app.webXml`.
+Properties per profile: `maven.compiler.release`, `jdk.version`, `app.sourceDirectory`, `app.testSourceDirectory`, `app.webXml`. The build uses `maven.compiler.release` (not separate `source`/`target`) so the compiler enforces the target JDK's API surface; `maven-compiler-plugin` is pinned with `<failOnWarning>true</failOnWarning>` (all profiles compile warning-clean).
 
 ## Architecture
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,12 @@ export PATH := $(HOME)/.local/share/mise/shims:$(PATH)
 
 CURRENTTAG := $(shell git describe --tags --abbrev=0 2>/dev/null || echo "dev")
 
+# act runner image — pin the DATED catthehacker tag. The floating act-* tags are
+# republished weekly; the dated form is immutable. Renovate bumps it via the
+# Makefile custom manager (see renovate.json).
+# renovate: datasource=docker depName=catthehacker/ubuntu versioning=loose
+ACT_UBUNTU_VERSION := act-latest-20260615
+
 PROFILE ?= tomcat9
 ALLOWED_PROFILES := tomcat9 tomcat10 tomcat11
 
@@ -30,7 +36,7 @@ help:
 	@echo
 	@echo "Commands :"
 	@echo
-	@grep -E '[a-zA-Z\.\-]+:.*?@ .*$$' $(MAKEFILE_LIST)| tr -d '#' | awk 'BEGIN {FS = ":.*?@ "}; {printf "\033[32m%-18s\033[0m - %s\n", $$1, $$2}'
+	@grep -E '[a-zA-Z\.\-]+:.*?@ .*$$' $(MAKEFILE_LIST)| tr -d '#' | awk 'BEGIN {FS = ":.*?@ "}; {printf "\033[32m%-20s\033[0m - %s\n", $$1, $$2}'
 
 #deps: @ Install the toolchain (java, maven, node, act) via mise
 deps:
@@ -119,8 +125,26 @@ release:
 
 #ci-run: @ Run GitHub Actions workflow locally using act (act installed via mise)
 ci-run: deps
-	@act push --container-architecture linux/amd64 \
-		--artifact-server-path /tmp/act-artifacts
+	@docker container prune -f >/dev/null 2>&1 || true
+	@# Forward a GitHub token (env-only via --secret KEY, never in argv) so mise's
+	@# aqua: backend can query the GitHub release API during `mise install` inside
+	@# the runner without hitting the 60-req/h anonymous rate limit. Derived from
+	@# the gh CLI. --pull=false reuses the cached runner image (avoids the
+	@# containerd-snapshotter RWLayer race). Random artifact port + mktemp dir keep
+	@# concurrent runs from colliding.
+	@if [ -z "$${GITHUB_TOKEN:-}" ] && command -v gh >/dev/null 2>&1; then \
+		export GITHUB_TOKEN="$$(gh auth token 2>/dev/null)"; \
+	fi; \
+	ARTIFACT_PATH=$$(mktemp -d -t act-artifacts.XXXXXX); \
+	ACT_PORT=$$(shuf -i 40000-59999 -n 1); \
+	secret_args=(); \
+	[ -n "$${GITHUB_TOKEN:-}" ] && secret_args+=(--secret GITHUB_TOKEN); \
+	act push --container-architecture linux/amd64 \
+		--pull=false \
+		-P ubuntu-latest=catthehacker/ubuntu:$(ACT_UBUNTU_VERSION) \
+		--artifact-server-port "$$ACT_PORT" \
+		--artifact-server-path "$$ARTIFACT_PATH" \
+		"$${secret_args[@]}"
 
 #renovate-validate: @ Validate Renovate configuration (node provided by mise)
 renovate-validate: deps

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ Run `make help` to see all available targets.
 | `make jetty-run` | Run locally with embedded Jetty server |
 | `make verify-all` | Verify build compiles for all Tomcat profiles |
 
+### Code Quality & Security
+
+| Target | Description |
+|--------|-------------|
+| `make static-check` | Run all static analysis (`lint` + `trivy-fs` + `gitleaks-scan`) |
+| `make trivy-fs` | Scan the filesystem for vulnerabilities and secrets ([Trivy](https://github.com/aquasecurity/trivy)) |
+| `make gitleaks-scan` | Scan the working tree for committed secrets ([gitleaks](https://github.com/gitleaks/gitleaks)) |
+
 ### Deployment
 
 | Target | Description |

--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,11 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <!-- Defaults for tomcat9 profile (overridden by other profiles) -->
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <!-- Defaults for tomcat9 profile (overridden by other profiles).
+             Use `release` (not source/target): it enforces the target JDK's
+             API surface and avoids the "system modules path not set" warning
+             when building on a newer local JDK. -->
+        <maven.compiler.release>11</maven.compiler.release>
         <jdk.version>11-tem</jdk.version>
         <app.sourceDirectory>src/main/java</app.sourceDirectory>
         <app.testSourceDirectory>src/test/java</app.testSourceDirectory>
@@ -40,6 +42,18 @@
         <sourceDirectory>${app.sourceDirectory}</sourceDirectory>
         <testSourceDirectory>${app.testSourceDirectory}</testSourceDirectory>
         <plugins>
+            <!-- Pinned (the other plugins are pinned too) + warnings-as-errors.
+                 All three profiles compile clean under `release`; any new
+                 warning (deprecation, unchecked) now fails the build instead
+                 of accumulating silently. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.15.0</version>
+                <configuration>
+                    <failOnWarning>true</failOnWarning>
+                </configuration>
+            </plugin>
             <!-- Resolve mockito-core's jar path into a property so Surefire can
                  load it as an explicit -javaagent (avoids the JDK 21+ "Dynamic
                  loading of agents will be disallowed" self-attach warning). -->
@@ -94,8 +108,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <maven.compiler.source>11</maven.compiler.source>
-                <maven.compiler.target>11</maven.compiler.target>
+                <maven.compiler.release>11</maven.compiler.release>
                 <jdk.version>11-tem</jdk.version>
             </properties>
             <dependencies>
@@ -127,8 +140,7 @@
         <profile>
             <id>tomcat10</id>
             <properties>
-                <maven.compiler.source>17</maven.compiler.source>
-                <maven.compiler.target>17</maven.compiler.target>
+                <maven.compiler.release>17</maven.compiler.release>
                 <jdk.version>17-tem</jdk.version>
                 <app.sourceDirectory>src/main/java-jakarta</app.sourceDirectory>
                 <app.testSourceDirectory>src/test/java-jakarta</app.testSourceDirectory>
@@ -163,8 +175,7 @@
         <profile>
             <id>tomcat11</id>
             <properties>
-                <maven.compiler.source>21</maven.compiler.source>
-                <maven.compiler.target>21</maven.compiler.target>
+                <maven.compiler.release>21</maven.compiler.release>
                 <jdk.version>21-tem</jdk.version>
                 <app.sourceDirectory>src/main/java-jakarta</app.sourceDirectory>
                 <app.testSourceDirectory>src/test/java-jakarta</app.testSourceDirectory>

--- a/renovate.json
+++ b/renovate.json
@@ -13,15 +13,38 @@
   "enabledManagers": [
     "maven",
     "github-actions",
-    "mise"
+    "mise",
+    "custom.regex"
   ],
   "prConcurrentLimit": 50,
   "prHourlyLimit": 0,
-  "platformAutomerge": true,
   "automerge": true,
   "automergeType": "pr",
   "automergeStrategy": "squash",
+  "platformAutomerge": false,
   "ignoreTests": false,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Makefile tool pins via inline # renovate: comments (e.g. ACT_UBUNTU_VERSION)",
+      "managerFilePatterns": [
+        "Makefile"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\n[A-Z0-9_]+\\s*[?:]?=\\s*(?<currentValue>\\S+)"
+      ]
+    },
+    {
+      "customType": "regex",
+      "description": "Tomcat versions in scripts/install-tomcat.sh via inline # renovate: comments",
+      "managerFilePatterns": [
+        "scripts/install-tomcat.sh"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\n[A-Z0-9_]+=\"(?<currentValue>[^\"]+)\""
+      ]
+    }
+  ],
   "vulnerabilityAlerts": {
     "labels": [
       "security"
@@ -34,6 +57,16 @@
       "description": "Wait 3 days before automerging major updates",
       "matchUpdateTypes": [
         "major"
+      ],
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "Hold mise github-tags tool bumps (aqua: act/trivy/gitleaks) 3 days so the upstream GitHub Release assets publish before the bump PR opens — avoids the tag-before-publish 404 (e.g. trivy v0.71.1, whose release workflow has failed mid-publish before).",
+      "matchManagers": [
+        "mise"
+      ],
+      "matchDatasources": [
+        "github-tags"
       ],
       "minimumReleaseAge": "3 days"
     },
@@ -52,6 +85,40 @@
       "addLabels": [
         "lang: java"
       ]
+    },
+    {
+      "description": "Pin JUnit to 5.x: JUnit 6 requires a Java 17 test runtime, but the tomcat9 profile's tests run on Java 11 (the minimum Tomcat 9 / javax.servlet runtime). Same deliberate version-lock as the Jetty/Servlet major guards below.",
+      "matchPackageNames": [
+        "/^org\\.junit/"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Tomcat 9 line in install-tomcat.sh — keep TOMCAT_9_VERSION on 9.0.x",
+      "matchPackageNames": [
+        "org.apache.tomcat:tomcat"
+      ],
+      "matchCurrentValue": "/^9\\./",
+      "allowedVersions": "/^9\\./"
+    },
+    {
+      "description": "Tomcat 10 line in install-tomcat.sh — keep TOMCAT_10_VERSION on 10.1.x",
+      "matchPackageNames": [
+        "org.apache.tomcat:tomcat"
+      ],
+      "matchCurrentValue": "/^10\\./",
+      "allowedVersions": "/^10\\./"
+    },
+    {
+      "description": "Tomcat 11 line in install-tomcat.sh — keep TOMCAT_11_VERSION on 11.0.x",
+      "matchPackageNames": [
+        "org.apache.tomcat:tomcat"
+      ],
+      "matchCurrentValue": "/^11\\./",
+      "allowedVersions": "/^11\\./"
     },
     {
       "description": "Disable Jetty major updates (version tied to Tomcat profile)",

--- a/scripts/install-tomcat.sh
+++ b/scripts/install-tomcat.sh
@@ -10,9 +10,12 @@ set -euo pipefail
 #   ./install-tomcat.sh --current 11             # set current symlink to 11
 #   ./install-tomcat.sh --versions 10 --current 10
 
-TOMCAT_9_VERSION="9.0.116"
-TOMCAT_10_VERSION="10.1.52"
-TOMCAT_11_VERSION="11.0.20"
+# renovate: datasource=maven depName=org.apache.tomcat:tomcat versioning=maven
+TOMCAT_9_VERSION="9.0.118"
+# renovate: datasource=maven depName=org.apache.tomcat:tomcat versioning=maven
+TOMCAT_10_VERSION="10.1.55"
+# renovate: datasource=maven depName=org.apache.tomcat:tomcat versioning=maven
+TOMCAT_11_VERSION="11.0.22"
 
 INSTALL_BASE="${HOME}/tomcat"
 CDN_MIRROR="https://dlcdn.apache.org/tomcat"


### PR DESCRIPTION
Autonomous project-health sweep (`/upgrade-analysis` → `/makefile` → `/ci-workflow` → `/renovate` → `/readme` → `/repo-about` → `/ship-it`).

## Real upgrades
- **Tomcat** in `install-tomcat.sh`: 9.0.116→**9.0.118**, 10.1.52→**10.1.55**, 11.0.20→**11.0.22** (were untracked; now Renovate-tracked with per-major constraints). Everything else was already at latest; the Java pin (`temurin-21.0.11`) is the current April-2026 CPU.

## Correctness
- **pom**: `maven.compiler.source/target` → `maven.compiler.release` (11/17/21) + pinned `maven-compiler-plugin` with `failOnWarning=true`. Silences the "system modules path not set" warning and turns warnings into a real CI gate. Verified warning-clean across all 3 profiles + tests.

## JUnit 6 decision
Kept JUnit **5.14.4** and added a Renovate major-guard. JUnit 6 requires a Java 17 test runtime, but the `tomcat9` profile tests on Java 11 (Tomcat 9 / `javax.servlet` minimum). Not upgrading is the correct call — same deliberate version-lock as the existing Jetty/Servlet guards. JUnit 5.14.x is fully maintained.

## CI / Renovate hardening
- `ci.yml`: re-include `CLAUDE.md` in the code paths-filter; tag pushes force `code=true` (never skip a tagged release).
- `cleanup-runs.yml`: **per-workflow** run retention (a global `KEEP_MINIMUM` can deregister a low-frequency workflow) + cache-cleanup job.
- `renovate.json`: JUnit major-guard, Tomcat + `ACT_UBUNTU_VERSION` custom managers, mise `github-tags` 3-day buffer (tag-before-publish 404 guard), `platformAutomerge:false`.
- `Makefile`: hardened `ci-run` (`--pull=false`, dated catthehacker pin, `GITHUB_TOKEN` forward), help-column alignment.

## ⚠️ Follow-up for you (governance — not auto-applied)
`master` has **no required status checks**, so Renovate automerge could merge a red PR. `platformAutomerge:false` (in this PR) makes Renovate gate on green CI itself, but the categorical fix is to add **`ci-pass`** as a required status check (Settings → Branches/Rules). I left that to you since it changes the merge contract for all contributors.

## Verification
`make ci` green (build + test + trivy-fs + gitleaks across the default profile); `make verify-all` green on all 3 profiles; `renovate-config-validator` passed; customManager regexes confirmed extracting all pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)