### PR TITLE
docs: C4 architecture hero diagram + mermaid-lint gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,11 @@ CURRENTTAG := $(shell git describe --tags --abbrev=0 2>/dev/null || echo "dev")
 # renovate: datasource=docker depName=catthehacker/ubuntu versioning=loose
 ACT_UBUNTU_VERSION := act-latest-20260615
 
+# Mermaid CLI image for linting the README's ```mermaid diagram (same engine
+# GitHub renders with). Renovate bumps it via the Makefile custom manager.
+# renovate: datasource=docker depName=minlag/mermaid-cli
+MERMAID_CLI_VERSION := 11.15.0
+
 PROFILE ?= tomcat9
 ALLOWED_PROFILES := tomcat9 tomcat10 tomcat11
 
@@ -68,8 +73,33 @@ trivy-fs: deps
 gitleaks-scan: deps
 	@gitleaks dir . --no-banner --redact
 
-#static-check: @ Run all static analysis (lint + trivy-fs + gitleaks)
-static-check: lint trivy-fs gitleaks-scan
+#mermaid-lint: @ Validate Mermaid diagrams in markdown (minlag/mermaid-cli, GitHub's engine)
+mermaid-lint:
+	@command -v docker >/dev/null 2>&1 || { echo "ERROR: docker is required for mermaid-lint"; exit 1; }
+	@set -euo pipefail; \
+	MD_FILES=$$(grep -lF '```mermaid' README.md CLAUDE.md 2>/dev/null || true); \
+	if [ -z "$$MD_FILES" ]; then echo "No Mermaid blocks found — skipping."; exit 0; fi; \
+	IMAGE=minlag/mermaid-cli:$(MERMAID_CLI_VERSION); \
+	for attempt in 1 2 3; do \
+		if docker pull --quiet "$$IMAGE" >/dev/null 2>&1; then break; fi; \
+		if [ "$$attempt" -eq 3 ]; then echo "ERROR: docker pull $$IMAGE failed after 3 attempts"; exit 1; fi; \
+		delay=$$((attempt * 5)); echo "  ! docker pull failed (attempt $$attempt/3); retrying in $${delay}s..."; sleep "$$delay"; \
+	done; \
+	FAILED=0; \
+	for md in $$MD_FILES; do \
+		echo "Validating Mermaid blocks in $$md..."; \
+		LOG=$$(mktemp); \
+		if docker run --rm -v "$$PWD:/data:ro" "$$IMAGE" -i "/data/$$md" -o "/tmp/$$(basename $$md .md).svg" >"$$LOG" 2>&1; then \
+			echo "  ✓ All blocks rendered cleanly."; \
+		else \
+			echo "  ✗ Parse error in $$md:"; sed 's/^/    /' "$$LOG"; FAILED=$$((FAILED + 1)); \
+		fi; \
+		rm -f "$$LOG"; \
+	done; \
+	if [ "$$FAILED" -gt 0 ]; then echo "Mermaid lint: $$FAILED file(s) had parse errors."; exit 1; fi
+
+#static-check: @ Run all static analysis (lint + trivy-fs + gitleaks + mermaid-lint)
+static-check: lint trivy-fs gitleaks-scan mermaid-lint
 	@echo "static-check passed."
 
 #run: @ Run locally with Jetty (alias for jetty-run)
@@ -150,6 +180,6 @@ ci-run: deps
 renovate-validate: deps
 	@npx --yes renovate@latest --platform=local
 
-.PHONY: help deps clean build test lint trivy-fs gitleaks-scan static-check \
+.PHONY: help deps clean build test lint trivy-fs gitleaks-scan mermaid-lint static-check \
 	run ci ci-run verify-all jetty-run deploy tomcat-install tomcat-switch \
 	deps-print-updates deps-update release renovate-validate

--- a/README.md
+++ b/README.md
@@ -9,6 +9,28 @@ A minimal Java web application that replaces Tomcat's default ROOT webapp (`$TOM
 
 Supports **Tomcat 9**, **10**, and **11** via Maven profiles.
 
+```mermaid
+C4Container
+    title ROOT WAR — request flow
+
+    Person(user, "User", "Web browser")
+
+    Container_Boundary(container, "Servlet container — Tomcat 9/10/11 or embedded Jetty") {
+        Container(html, "index.html", "Static HTML", "Welcome page served at /")
+        Container(servlet, "InfoServlet", "Java Servlet (javax or jakarta)", "Mapped at /infoservlet; forwards to the JSP")
+        Container(jsp, "index.jsp", "JSP", "Renders server info, request headers, and cookies")
+    }
+
+    Rel(user, html, "GET /", "HTTP")
+    Rel(user, servlet, "GET /infoservlet", "HTTP")
+    Rel(user, jsp, "GET /index.jsp", "HTTP")
+    Rel(servlet, jsp, "forwards via RequestDispatcher")
+
+    UpdateLayoutConfig($c4ShapeInRow="1", $c4BoundaryInRow="1")
+```
+
+The WAR deploys at context path `/` (replacing the container's default ROOT app). A single codebase targets both the `javax.servlet` (Tomcat 9) and `jakarta.servlet` (Tomcat 10/11) namespaces via Maven profiles that select the matching source tree (`src/main/java` vs `src/main/java-jakarta`).
+
 ## Quick Start
 
 ```bash
@@ -75,9 +97,10 @@ Run `make help` to see all available targets.
 
 | Target | Description |
 |--------|-------------|
-| `make static-check` | Run all static analysis (`lint` + `trivy-fs` + `gitleaks-scan`) |
+| `make static-check` | Run all static analysis (`lint` + `trivy-fs` + `gitleaks-scan` + `mermaid-lint`) |
 | `make trivy-fs` | Scan the filesystem for vulnerabilities and secrets ([Trivy](https://github.com/aquasecurity/trivy)) |
 | `make gitleaks-scan` | Scan the working tree for committed secrets ([gitleaks](https://github.com/gitleaks/gitleaks)) |
+| `make mermaid-lint` | Validate the README Mermaid diagram with [mermaid-cli](https://github.com/mermaid-js/mermaid-cli) (GitHub's renderer) |
 
 ### Deployment
 


### PR DESCRIPTION
Validated the README against the codebase fact-by-fact (all claims correct) and added the one missing piece per the `/readme` canonical structure — a hero architecture diagram.

## README fact-check (all ✓)
- Servlet mapping `/infoservlet`, welcome `index.html`, context path `/` — match `web.xml`/`web-jakarta.xml`/`context.xml`.
- Description claim "server info, request headers, cookies via a servlet and JSP page" — `InfoServlet` forwards to `index.jsp` (verified `RequestDispatcher`); `index.jsp` renders all three.
- Build Profiles table, CI matrix (JDK 11/18/25 × Tomcat 9/10/11), all Make targets, all 4 screenshot PNGs — verified against `pom.xml`, `ci.yml`, `Makefile`, `images/`.

## Added
- **Mermaid `C4Container` hero** under the description: browser → servlet container (Tomcat 9/10/11 or Jetty) → `index.html` / `InfoServlet` → `index.jsp`. Every node + relationship is grounded in source.
- **`make mermaid-lint`** (minlag/mermaid-cli `11.15.0`, GitHub's own renderer, Renovate-pinned) wired into `static-check` — a broken diagram now fails CI instead of silently breaking README rendering on github.com.

## Verification
- `make mermaid-lint` passes on the diagram; **proven to fail** on an invalid diagram type / garbage body (Error 1) — not a false-confidence gate.
- `make ci` green end-to-end with `mermaid-lint` in `static-check`.

## /repo-about
The About one-liner ("Drop-in ROOT webapp for Tomcat 9, 10 & 11 — server info, headers, cookies; one codebase spans the javax→jakarta split via Maven profiles") was fact-checked against the same sources — every claim holds. No change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)