### PR TITLE
fix: shrink hero diagram + reconcile JDK/CI/ruleset facts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,13 +34,13 @@ Unit tests use **JUnit 5 + Mockito** (run via Surefire). Test sources are profil
 
 ## Maven Profiles
 
-| Profile | Tomcat | Servlet API | `release` | JDK |
-|---------|--------|-------------|-----------|-----|
-| `tomcat9` (default) | 9.0.x | `javax.servlet` 4.0 | 11 | 11-tem |
-| `tomcat10` | 10.1.x | `jakarta.servlet` 6.1 | 17 | 17-tem |
-| `tomcat11` | 11.0.x | `jakarta.servlet` 6.1 | 21 | 21-tem |
+| Profile | Tomcat | Servlet API | `maven.compiler.release` | CI-tested JDKs |
+|---------|--------|-------------|--------------------------|----------------|
+| `tomcat9` (default) | 9.0.x | `javax.servlet` 4.0 | 11 | 11, 18, 25 |
+| `tomcat10` | 10.1.x | `jakarta.servlet` 6.1 | 17 | 18, 25 |
+| `tomcat11` | 11.0.x | `jakarta.servlet` 6.1 | 21 | 25 |
 
-Properties per profile: `maven.compiler.release`, `jdk.version`, `app.sourceDirectory`, `app.testSourceDirectory`, `app.webXml`. The build uses `maven.compiler.release` (not separate `source`/`target`) so the compiler enforces the target JDK's API surface; `maven-compiler-plugin` is pinned with `<failOnWarning>true</failOnWarning>` (all profiles compile warning-clean).
+Properties per profile: `maven.compiler.release`, `app.sourceDirectory`, `app.testSourceDirectory`, `app.webXml`. The build uses `maven.compiler.release` (not separate `source`/`target`) so the compiler enforces the target JDK's API surface; `maven-compiler-plugin` is pinned with `<failOnWarning>true</failOnWarning>` (all profiles compile warning-clean). The per-leg CI JDK is set via `MISE_JAVA_VERSION` (see `.github/workflows/ci.yml`) — the `release` level is the bytecode target, the CI-tested JDKs are the runtimes each profile is verified on.
 
 ## Architecture
 
@@ -75,11 +75,12 @@ The `Makefile` wraps Maven and the scripts. All profile-aware targets accept `PR
 GitHub Actions (`ci.yml`) runs on push to `master`, tags `v*`, and pull requests. The toolchain is provided by `jdx/mise-action`; the JDK for each matrix leg is set via the `MISE_JAVA_VERSION` env override. Jobs:
 
 - **changes** — `dorny/paths-filter` detects whether code paths changed (docs-only changes skip the build).
+- **static-check** — runs `make static-check` (`lint` + `trivy-fs` + `gitleaks-scan` + `mermaid-lint`).
 - **build** — runs `make lint`, `make build`, `make test` across the matrix:
   - **Tomcat 9**: JDK 11, 18, 25 (Temurin)
   - **Tomcat 10**: JDK 18, 25 (Temurin)
   - **Tomcat 11**: JDK 25 (Temurin)
-- **ci-pass** — aggregator gate; the single required status check.
+- **ci-pass** — aggregator gate; succeeds only if every job passed. It is the single required status check on `master` (enforced via a repository ruleset).
 
 ## Skills
 

--- a/README.md
+++ b/README.md
@@ -10,23 +10,18 @@ A minimal Java web application that replaces Tomcat's default ROOT webapp (`$TOM
 Supports **Tomcat 9**, **10**, and **11** via Maven profiles.
 
 ```mermaid
-C4Container
-    title ROOT WAR — request flow
-
-    Person(user, "User", "Web browser")
-
-    Container_Boundary(container, "Servlet container — Tomcat 9/10/11 or embedded Jetty") {
-        Container(html, "index.html", "Static HTML", "Welcome page served at /")
-        Container(servlet, "InfoServlet", "Java Servlet (javax or jakarta)", "Mapped at /infoservlet; forwards to the JSP")
-        Container(jsp, "index.jsp", "JSP", "Renders server info, request headers, and cookies")
-    }
-
-    Rel(user, html, "GET /", "HTTP")
-    Rel(user, servlet, "GET /infoservlet", "HTTP")
-    Rel(user, jsp, "GET /index.jsp", "HTTP")
-    Rel(servlet, jsp, "forwards via RequestDispatcher")
-
-    UpdateLayoutConfig($c4ShapeInRow="1", $c4BoundaryInRow="1")
+flowchart LR
+    user(["User<br/>(web browser)"])
+    subgraph sc["Servlet container — Tomcat 9/10/11 or embedded Jetty · ROOT.war at /"]
+        direction LR
+        html["index.html<br/>welcome page"]
+        servlet["InfoServlet<br/>/infoservlet"]
+        jsp["index.jsp<br/>server info · headers · cookies"]
+    end
+    user -->|GET /| html
+    user -->|GET /infoservlet| servlet
+    user -->|GET /index.jsp| jsp
+    servlet -->|forwards via RequestDispatcher| jsp
 ```
 
 The WAR deploys at context path `/` (replacing the container's default ROOT app). A single codebase targets both the `javax.servlet` (Tomcat 9) and `jakarta.servlet` (Tomcat 10/11) namespaces via Maven profiles that select the matching source tree (`src/main/java` vs `src/main/java-jakarta`).
@@ -48,7 +43,7 @@ The toolchain (JDK, Maven, node, act) is managed by [mise](https://mise.jdx.dev/
 |------|---------|---------|
 | [GNU Make](https://www.gnu.org/software/make/) | 3.81+ | Build orchestration |
 | [mise](https://mise.jdx.dev/) | latest | Toolchain version manager (provides JDK, Maven, node, act) |
-| [JDK](https://adoptium.net/) | 11/17/21 | Java runtime and compiler (provided by mise; local dev uses JDK 21) |
+| [JDK](https://adoptium.net/) | 21 (Temurin) | Java compiler/runtime — provided by mise; local dev builds every profile with JDK 21 (bytecode targets 11/17/21) |
 | [Maven](https://maven.apache.org/) | 3.9+ | Build and dependency management (provided by mise) |
 | [act](https://github.com/nektos/act) | pinned | Local GitHub Actions testing (provided by mise, optional) |
 
@@ -63,11 +58,11 @@ make deps                    # install JDK, Maven, node, act from .mise.toml
 
 Each profile targets a specific Tomcat version with the appropriate Servlet API:
 
-| Profile | Tomcat | Servlet API | Java | JDK |
-|---------|--------|-------------|------|-----|
-| `tomcat9` (default) | 9.0.x | `javax.servlet` 4.0 | 11 | 11-tem |
-| `tomcat10` | 10.1.x | `jakarta.servlet` 6.1 | 17 | 17-tem |
-| `tomcat11` | 11.0.x | `jakarta.servlet` 6.1 | 21 | 21-tem |
+| Profile | Tomcat | Servlet API | Java release | CI-tested JDKs |
+|---------|--------|-------------|--------------|----------------|
+| `tomcat9` (default) | 9.0.x | `javax.servlet` 4.0 | 11 | 11, 18, 25 |
+| `tomcat10` | 10.1.x | `jakarta.servlet` 6.1 | 17 | 18, 25 |
+| `tomcat11` | 11.0.x | `jakarta.servlet` 6.1 | 21 | 25 |
 
 Select a profile with `PROFILE=`:
 
@@ -246,12 +241,13 @@ GitHub Actions runs on every push to `master`, tags `v*`, and pull requests.
 | Job | Triggers | Purpose |
 |-----|----------|---------|
 | **changes** | push (master, tags), PR | Detect whether code paths changed (skips the build on docs-only changes) |
-| **build** | when `changes` reports code | Lint, Build, Test across the JDK × Tomcat matrix |
-| **ci-pass** | always | Aggregator gate — the single required status check |
+| **static-check** | when `changes` reports code | `make static-check` — `lint` + `trivy-fs` + `gitleaks-scan` + `mermaid-lint` |
+| **build** | when `changes` reports code | `make lint` + `make build` + `make test` across the JDK × Tomcat matrix |
+| **ci-pass** | always | Aggregator gate — succeeds only if every job passed; the single required status check on `master` (repository ruleset) |
 
 The **build** job uses a matrix strategy testing across JDK 11/18/25 with Tomcat 9, JDK 18/25 with Tomcat 10, and JDK 25 with Tomcat 11. The JDK for each leg is provided by [mise](https://mise.jdx.dev/) via the `MISE_JAVA_VERSION` override.
 
-[Renovate](https://docs.renovatebot.com/) keeps dependencies up to date with PR automerge enabled (gated on the `ci-pass` check).
+[Renovate](https://docs.renovatebot.com/) keeps dependencies up to date and automerges PRs once CI is green.
 
 ## Screenshots
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,6 @@
              API surface and avoids the "system modules path not set" warning
              when building on a newer local JDK. -->
         <maven.compiler.release>11</maven.compiler.release>
-        <jdk.version>11-tem</jdk.version>
         <app.sourceDirectory>src/main/java</app.sourceDirectory>
         <app.testSourceDirectory>src/test/java</app.testSourceDirectory>
         <app.webXml>src/main/webapp/WEB-INF/web.xml</app.webXml>
@@ -109,7 +108,6 @@
             </activation>
             <properties>
                 <maven.compiler.release>11</maven.compiler.release>
-                <jdk.version>11-tem</jdk.version>
             </properties>
             <dependencies>
                 <dependency>
@@ -141,7 +139,6 @@
             <id>tomcat10</id>
             <properties>
                 <maven.compiler.release>17</maven.compiler.release>
-                <jdk.version>17-tem</jdk.version>
                 <app.sourceDirectory>src/main/java-jakarta</app.sourceDirectory>
                 <app.testSourceDirectory>src/test/java-jakarta</app.testSourceDirectory>
                 <app.webXml>src/main/webapp/WEB-INF/web-jakarta.xml</app.webXml>
@@ -176,7 +173,6 @@
             <id>tomcat11</id>
             <properties>
                 <maven.compiler.release>21</maven.compiler.release>
-                <jdk.version>21-tem</jdk.version>
                 <app.sourceDirectory>src/main/java-jakarta</app.sourceDirectory>
                 <app.testSourceDirectory>src/test/java-jakarta</app.testSourceDirectory>
                 <app.webXml>src/main/webapp/WEB-INF/web-jakarta.xml</app.webXml>


### PR DESCRIPTION
Addresses the reconciliation gaps surfaced in review (the diagram size + the JDK/CI doc drift), plus updates docs for the newly-added `ci-pass` ruleset.

## Hero diagram
The Mermaid `C4Container` rendered **747×1289** (a ~1289px-tall tower — C4's single-column layout + large fixed boxes). Replaced with a compact `flowchart LR` (**988×373**, ~3.5× shorter). Same content, verified by `mermaid-lint`.

## Doc reconciliation (README + CLAUDE.md vs code / CI / ruleset)
| Was | Now (source of truth) |
|---|---|
| Build Profiles "JDK" = 11-tem/17-tem/21-tem (from vestigial pom `jdk.version`) | **removed the dead property**; table = Java release `11/17/21` + CI-tested JDKs `11,18,25 / 18,25 / 25` (matches `ci.yml`) |
| Prerequisites "JDK 11/17/21" | "JDK 21 (Temurin); bytecode targets 11/17/21" |
| CI job table: changes / build / ci-pass | added **`static-check`** (ci.yml has 4 jobs) |
| "ci-pass = the single required status check" (was false — none configured) | now **true** — `ci-pass` is required via repository ruleset; docs say so accurately |
| Renovate "PR automerge gated on ci-pass" | "automerges PRs once CI is green" |

`renovate.json` `platformAutomerge: false` kept deliberately — required-check + `platformAutomerge:false` together close both the gate and the auto-merge registration race.

## Verified
`make ci` green (mermaid-lint on the new flowchart + build + test); `make verify-all` green on all 3 profiles after the `jdk.version` removal; `ci-pass` ruleset confirmed via `gh api .../rules/branches/master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)