### PR TITLE
ci: expand JDK test matrix per profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,19 +78,27 @@ jobs:
 
       matrix:
         include:
-          # Tomcat 9 (javax.servlet, Servlet 4.0) - compiler target 11
+          # Tomcat 9 (javax.servlet, Servlet 4.0) - compiler release 11
           - java: '11'
             maven_profile: 'tomcat9'
+          - java: '17'
+            maven_profile: 'tomcat9'
           - java: '18'
+            maven_profile: 'tomcat9'
+          - java: '21'
             maven_profile: 'tomcat9'
           - java: '25'
             maven_profile: 'tomcat9'
-          # Tomcat 10 (jakarta.servlet, Servlet 6.1) - compiler target 17
+          # Tomcat 10 (jakarta.servlet, Servlet 6.1) - compiler release 17
+          - java: '17'
+            maven_profile: 'tomcat10'
           - java: '18'
             maven_profile: 'tomcat10'
           - java: '25'
             maven_profile: 'tomcat10'
-          # Tomcat 11 (jakarta.servlet, Servlet 6.1) - compiler target 21
+          # Tomcat 11 (jakarta.servlet, Servlet 6.1) - compiler release 21
+          - java: '21'
+            maven_profile: 'tomcat11'
           - java: '25'
             maven_profile: 'tomcat11'
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,9 +36,9 @@ Unit tests use **JUnit 5 + Mockito** (run via Surefire). Test sources are profil
 
 | Profile | Tomcat | Servlet API | `maven.compiler.release` | CI-tested JDKs |
 |---------|--------|-------------|--------------------------|----------------|
-| `tomcat9` (default) | 9.0.x | `javax.servlet` 4.0 | 11 | 11, 18, 25 |
-| `tomcat10` | 10.1.x | `jakarta.servlet` 6.1 | 17 | 18, 25 |
-| `tomcat11` | 11.0.x | `jakarta.servlet` 6.1 | 21 | 25 |
+| `tomcat9` (default) | 9.0.x | `javax.servlet` 4.0 | 11 | 11, 17, 18, 21, 25 |
+| `tomcat10` | 10.1.x | `jakarta.servlet` 6.1 | 17 | 17, 18, 25 |
+| `tomcat11` | 11.0.x | `jakarta.servlet` 6.1 | 21 | 21, 25 |
 
 Properties per profile: `maven.compiler.release`, `app.sourceDirectory`, `app.testSourceDirectory`, `app.webXml`. The build uses `maven.compiler.release` (not separate `source`/`target`) so the compiler enforces the target JDK's API surface; `maven-compiler-plugin` is pinned with `<failOnWarning>true</failOnWarning>` (all profiles compile warning-clean). The per-leg CI JDK is set via `MISE_JAVA_VERSION` (see `.github/workflows/ci.yml`) — the `release` level is the bytecode target, the CI-tested JDKs are the runtimes each profile is verified on.
 
@@ -77,9 +77,9 @@ GitHub Actions (`ci.yml`) runs on push to `master`, tags `v*`, and pull requests
 - **changes** — `dorny/paths-filter` detects whether code paths changed (docs-only changes skip the build).
 - **static-check** — runs `make static-check` (`lint` + `trivy-fs` + `gitleaks-scan` + `mermaid-lint`).
 - **build** — runs `make lint`, `make build`, `make test` across the matrix:
-  - **Tomcat 9**: JDK 11, 18, 25 (Temurin)
-  - **Tomcat 10**: JDK 18, 25 (Temurin)
-  - **Tomcat 11**: JDK 25 (Temurin)
+  - **Tomcat 9**: JDK 11, 17, 18, 21, 25 (Temurin)
+  - **Tomcat 10**: JDK 17, 18, 25 (Temurin)
+  - **Tomcat 11**: JDK 21, 25 (Temurin)
 - **ci-pass** — aggregator gate; succeeds only if every job passed. It is the single required status check on `master` (enforced via a repository ruleset).
 
 ## Skills

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ Each profile targets a specific Tomcat version with the appropriate Servlet API:
 
 | Profile | Tomcat | Servlet API | Java release | CI-tested JDKs |
 |---------|--------|-------------|--------------|----------------|
-| `tomcat9` (default) | 9.0.x | `javax.servlet` 4.0 | 11 | 11, 18, 25 |
-| `tomcat10` | 10.1.x | `jakarta.servlet` 6.1 | 17 | 18, 25 |
-| `tomcat11` | 11.0.x | `jakarta.servlet` 6.1 | 21 | 25 |
+| `tomcat9` (default) | 9.0.x | `javax.servlet` 4.0 | 11 | 11, 17, 18, 21, 25 |
+| `tomcat10` | 10.1.x | `jakarta.servlet` 6.1 | 17 | 17, 18, 25 |
+| `tomcat11` | 11.0.x | `jakarta.servlet` 6.1 | 21 | 21, 25 |
 
 Select a profile with `PROFILE=`:
 
@@ -245,7 +245,7 @@ GitHub Actions runs on every push to `master`, tags `v*`, and pull requests.
 | **build** | when `changes` reports code | `make lint` + `make build` + `make test` across the JDK × Tomcat matrix |
 | **ci-pass** | always | Aggregator gate — succeeds only if every job passed; the single required status check on `master` (repository ruleset) |
 
-The **build** job uses a matrix strategy testing across JDK 11/18/25 with Tomcat 9, JDK 18/25 with Tomcat 10, and JDK 25 with Tomcat 11. The JDK for each leg is provided by [mise](https://mise.jdx.dev/) via the `MISE_JAVA_VERSION` override.
+The **build** job uses a matrix strategy testing across JDK 11/17/18/21/25 with Tomcat 9, JDK 17/18/25 with Tomcat 10, and JDK 21/25 with Tomcat 11. The JDK for each leg is provided by [mise](https://mise.jdx.dev/) via the `MISE_JAVA_VERSION` override.
 
 [Renovate](https://docs.renovatebot.com/) keeps dependencies up to date and automerges PRs once CI is green.
 


### PR DESCRIPTION
Broadens the per-profile CI JDK matrix as requested. Default (local dev) stays JDK 21 — `.mise.toml` unchanged; only the CI matrix legs change.

| Profile | `maven.compiler.release` | CI-tested JDKs |
|---|---|---|
| tomcat9 | 11 | 11, 17, 18, 21, 25 |
| tomcat10 | 17 | 17, 18, 25 |
| tomcat11 | 21 | 21, 25 |

Every leg is valid (each JDK ≥ the profile's `release` level). 6 → 10 build legs.

**Docs updated:** README Build Profiles table + CI/CD prose, CLAUDE.md profile table + CI section. The hero flowchart has no JDK references, so it's unchanged (considered, not skipped).

**Verified locally** (the new release/JDK combos): tomcat9@JDK17, tomcat10@JDK17, tomcat11@JDK21 — all BUILD SUCCESS + tests pass; `actionlint` clean on the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)