### PR TITLE
chore: project-review fixes — CI hardening, renovate digest exemption, doc accuracy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,13 @@ jobs:
 
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     outputs:
       # Tag pushes always run the full pipeline: the tag SHA usually equals
       # master HEAD, so paths-filter (base: master) would see an empty diff and
       # skip every gated job, silently leaving a tagged release un-verified.
       code: ${{ startsWith(github.ref, 'refs/tags/') && 'true' || steps.filter.outputs.code }}
+      docs: ${{ steps.filter.outputs.docs }}
     steps:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
@@ -46,6 +48,11 @@ jobs:
               # CLAUDE.md is project config (build conventions / skill mappings),
               # not docs — its edits MUST run CI (/ci-workflow §15c).
               - 'CLAUDE.md'
+            # README.md carries a ```mermaid diagram. A README-only edit is NOT
+            # `code` (it must not trigger the 11-leg build), but it still needs
+            # mermaid-lint so a broken diagram can't merge unvalidated.
+            docs:
+              - 'README.md'
 
   static-check:
 
@@ -53,26 +60,30 @@ jobs:
     if: ${{ needs.changes.outputs.code == 'true' }}
 
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
 
     - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
-    - name: Set up tools (mise)
+    - name: Set up mise
       uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
       with:
         install: true
         cache: true
 
-    - name: Static analysis (lint + trivy-fs + gitleaks)
+    - name: Static check
       run: make static-check
 
   build:
 
-    needs: [ changes ]
+    # Gate the expensive 11-leg matrix behind the cheap static-check job so a
+    # lint/trivy/gitleaks failure fails fast before burning matrix runner minutes.
+    needs: [ changes, static-check ]
     if: ${{ needs.changes.outputs.code == 'true' }}
 
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     strategy:
 
@@ -111,7 +122,7 @@ jobs:
 
     - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
-    - name: Set up tools (mise)
+    - name: Set up mise
       uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
       with:
         install: true
@@ -135,9 +146,27 @@ jobs:
     - name: Test
       run: make test PROFILE=${{ matrix.maven_profile }}
 
+  mermaid-lint:
+
+    # When code changed, static-check already runs mermaid-lint. This job covers
+    # docs-only edits (README.md) so a broken Mermaid diagram cannot merge
+    # unvalidated (/ci-workflow §15h). Uses docker directly — no mise needed.
+    needs: [ changes ]
+    if: ${{ needs.changes.outputs.docs == 'true' && needs.changes.outputs.code != 'true' }}
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+
+    - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+
+    - name: Lint Mermaid diagrams
+      run: make mermaid-lint
+
   ci-pass:
     if: always()
-    needs: [ changes, static-check, build ]
+    needs: [ changes, static-check, build, mermaid-lint ]
     runs-on: ubuntu-latest
     steps:
       - name: Verify all jobs passed

--- a/.github/workflows/cleanup-runs.yml
+++ b/.github/workflows/cleanup-runs.yml
@@ -13,6 +13,7 @@ concurrency:
 permissions:
   contents: read
   actions: write
+  pull-requests: read
 
 jobs:
   cleanup-runs:
@@ -26,17 +27,28 @@ jobs:
       - name: Delete old workflow runs
         run: |
           CUTOFF=$(date -u -d "${RETAIN_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ)
+          # Open PRs' head SHAs MUST be preserved: deleting an open PR's run
+          # removes its `ci-pass` required check, making the PR silently
+          # un-mergeable (mergeStateStatus=BLOCKED, 0 checks). Slow Renovate
+          # PRs older than RETAIN_DAYS are the classic victim.
+          OPEN_SHAS=$(gh pr list --repo "${{ github.repository }}" \
+            --state open --json headRefOid --jq '[.[].headRefOid]')
           # Retain the newest KEEP_MINIMUM runs PER WORKFLOW (group_by
-          # .workflowName), THEN delete any remaining run older than CUTOFF.
+          # .workflowName), THEN delete any remaining run older than CUTOFF
+          # whose headSha is not an open PR's head.
           # A single GLOBAL minimum can purge every run of a low-frequency
           # workflow and flip it to `state: deleted` (deregistered).
           gh run list --repo "${{ github.repository }}" \
-            --json databaseId,createdAt,workflowName --limit 300 \
-          | jq -r --arg cutoff "$CUTOFF" --argjson keep "$KEEP_MINIMUM" '
+            --json databaseId,createdAt,workflowName,headSha --limit 300 \
+          | jq -r --arg cutoff "$CUTOFF" --argjson keep "$KEEP_MINIMUM" \
+                --argjson open "$OPEN_SHAS" '
               group_by(.workflowName)
               | map(sort_by(.createdAt) | reverse | .[$keep:])
               | add // []
-              | .[] | select(.createdAt < $cutoff) | .databaseId
+              | .[]
+              | select(.createdAt < $cutoff)
+              | select(.headSha as $s | ($open | index($s)) | not)
+              | .databaseId
             ' \
           | xargs -r -I{} gh run delete {} --repo "${{ github.repository }}"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,19 +68,22 @@ The two `InfoServlet.java` files are identical except for imports (`javax.servle
 
 ## Makefile
 
-The `Makefile` wraps Maven and the scripts. All profile-aware targets accept `PROFILE=tomcat9|tomcat10|tomcat11` (default: `tomcat9`). `make deps` installs the mise-pinned toolchain; mise shims are prepended to `PATH` so recipes find the pinned `java`/`mvn`/`act`.
+The `Makefile` wraps Maven and the scripts. All profile-aware targets accept `PROFILE=tomcat9|tomcat10|tomcat11` (default: `tomcat9`). mise shims are prepended to `PATH` so recipes find the pinned `java`/`mvn`/`act`.
 
 ## CI
 
 GitHub Actions (`ci.yml`) runs on push to `master`, tags `v*`, and pull requests. The toolchain is provided by `jdx/mise-action`; the JDK for each matrix leg is set via the `MISE_JAVA_VERSION` env override. Jobs:
 
-- **changes** — `dorny/paths-filter` detects whether code paths changed (docs-only changes skip the build).
+- **changes** — `dorny/paths-filter` detects whether `code` paths or `docs` (README.md) changed (docs-only changes skip the build).
 - **static-check** — runs `make static-check` (`lint` + `trivy-fs` + `gitleaks-scan` + `mermaid-lint`).
-- **build** — runs `make lint`, `make build`, `make test` across the matrix:
+- **build** — `needs: [changes, static-check]` (static-check gates the matrix so a lint failure fails fast). Runs `make lint`, `make build`, `make test` across the matrix:
   - **Tomcat 9**: JDK 11, 17, 18, 21, 25 (Temurin)
   - **Tomcat 10**: JDK 17, 18, 25 (Temurin)
   - **Tomcat 11**: JDK 21, 25 (Temurin)
+- **mermaid-lint** — runs `make mermaid-lint` on docs-only edits (README.md, no code change) so a broken Mermaid diagram can't merge unvalidated; when code changes, `static-check` already covers it.
 - **ci-pass** — aggregator gate; succeeds only if every job passed. It is the single required status check on `master` (enforced via a repository ruleset).
+
+**Static analysis scope**: dependency-CVE coverage is `trivy-fs` (scans `pom.xml` deps for HIGH/CRITICAL) plus Renovate. A 2-servlet demo WAR deliberately omits the heavier portfolio Java gates (OWASP dependency-check `cve-check`, google-java-format `format-check`, JaCoCo `coverage-check`) — they'd add CI secrets (NVD/OSS-Index), build time, and near-zero coverage signal on trivial code for no proportional benefit. Revisit if the codebase grows beyond the two `InfoServlet` sources.
 
 ## Skills
 

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,11 @@ ACT_UBUNTU_VERSION := act-latest-20260615
 # renovate: datasource=docker depName=minlag/mermaid-cli
 MERMAID_CLI_VERSION := 11.15.0
 
+# Renovate CLI for `make renovate-validate`. Pinned for reproducibility (no
+# floating @latest); bumped via the Makefile custom manager (see renovate.json).
+# renovate: datasource=npm depName=renovate
+RENOVATE_VERSION := 43.242.2
+
 PROFILE ?= tomcat9
 ALLOWED_PROFILES := tomcat9 tomcat10 tomcat11
 
@@ -178,8 +183,13 @@ ci-run: deps
 
 #renovate-validate: @ Validate Renovate configuration (node provided by mise)
 renovate-validate: deps
-	@npx --yes renovate@latest --platform=local
+	@npx --yes renovate@$(RENOVATE_VERSION) --platform=local
+
+#env-check: @ Report the resolved mise-managed toolchain versions
+env-check:
+	@command -v mise >/dev/null 2>&1 || { echo "Error: mise required. Install: https://mise.jdx.dev (curl https://mise.run | sh)"; exit 1; }
+	@mise ls --current
 
 .PHONY: help deps clean build test lint trivy-fs gitleaks-scan mermaid-lint static-check \
 	run ci ci-run verify-all jetty-run deploy tomcat-install tomcat-switch \
-	deps-print-updates deps-update release renovate-validate
+	deps-print-updates deps-update release renovate-validate env-check

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI](https://github.com/AndriyKalashnykov/tomcat-root-war/actions/workflows/ci.yml/badge.svg)](https://github.com/AndriyKalashnykov/tomcat-root-war/actions/workflows/ci.yml)
+[![CI](https://github.com/AndriyKalashnykov/tomcat-root-war/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/AndriyKalashnykov/tomcat-root-war/actions/workflows/ci.yml)
 [![Hits](https://hits.sh/github.com/AndriyKalashnykov/tomcat-root-war.svg?view=today-total&style=plastic)](https://hits.sh/github.com/AndriyKalashnykov/tomcat-root-war/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://app.renovatebot.com/dashboard#github/AndriyKalashnykov/tomcat-root-war)
@@ -120,6 +120,7 @@ Run `make help` to see all available targets.
 | `make deps-print-updates` | Print project dependency updates |
 | `make deps-update` | Update dependencies to latest releases |
 | `make renovate-validate` | Validate Renovate configuration |
+| `make env-check` | Report the resolved mise-managed toolchain versions |
 | `make release` | Create and push a new tag |
 
 All profile-aware targets default to `tomcat9`. Set `PROFILE=tomcat10` or `PROFILE=tomcat11` to override.
@@ -242,7 +243,8 @@ GitHub Actions runs on every push to `master`, tags `v*`, and pull requests.
 |-----|----------|---------|
 | **changes** | push (master, tags), PR | Detect whether code paths changed (skips the build on docs-only changes) |
 | **static-check** | when `changes` reports code | `make static-check` — `lint` + `trivy-fs` + `gitleaks-scan` + `mermaid-lint` |
-| **build** | when `changes` reports code | `make lint` + `make build` + `make test` across the JDK × Tomcat matrix |
+| **build** | when `changes` reports code (after **static-check**) | `make lint` + `make build` + `make test` across the JDK × Tomcat matrix |
+| **mermaid-lint** | docs-only edits (README.md, no code change) | `make mermaid-lint` — validates the README diagram on doc-only PRs (when code changes, **static-check** already covers it) |
 | **ci-pass** | always | Aggregator gate — succeeds only if every job passed; the single required status check on `master` (repository ruleset) |
 
 The **build** job uses a matrix strategy testing across JDK 11/17/18/21/25 with Tomcat 9, JDK 17/18/25 with Tomcat 10, and JDK 21/25 with Tomcat 11. The JDK for each leg is provided by [mise](https://mise.jdx.dev/) via the `MISE_JAVA_VERSION` override.
@@ -253,19 +255,19 @@ The **build** job uses a matrix strategy testing across JDK 11/17/18/21/25 with 
 
 Default welcome page &mdash; [http://localhost:8080/](http://localhost:8080/)
 
-<img src="images/http-8080-root.png" alt="index.html" width="800">
+<img src="images/http-8080-root.png" alt="index.html" width="600">
 
 JSP &mdash; [http://localhost:8080/index.jsp](http://localhost:8080/index.jsp)
 
-<img src="images/http-8080-index-jsp.png" alt="index.jsp" width="800">
+<img src="images/http-8080-index-jsp.png" alt="index.jsp" width="600">
 
 Servlet &mdash; [http://localhost:8080/infoservlet](http://localhost:8080/infoservlet)
 
-<img src="images/http-8080-infoservlet.png" alt="infoservlet" width="800">
+<img src="images/http-8080-infoservlet.png" alt="infoservlet" width="600">
 
 HTML &mdash; [http://localhost:8080/index.html](http://localhost:8080/index.html)
 
-<img src="images/http-8080-index-html.png" alt="index.html" width="800">
+<img src="images/http-8080-index-html.png" alt="index.html" width="600">
 
 ## Used In
 

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
             </build>
         </profile>
 
-        <!-- Tomcat 10: jakarta.servlet, Servlet 6.0, Java 11+ -->
+        <!-- Tomcat 10: jakarta.servlet, Servlet 6.1, Java 17+ -->
         <profile>
             <id>tomcat10</id>
             <properties>
@@ -168,7 +168,7 @@
             </build>
         </profile>
 
-        <!-- Tomcat 11: jakarta.servlet, Servlet 6.1, Java 17+ -->
+        <!-- Tomcat 11: jakarta.servlet, Servlet 6.1, Java 21+ -->
         <profile>
             <id>tomcat11</id>
             <properties>

--- a/renovate.json
+++ b/renovate.json
@@ -54,6 +54,16 @@
   },
   "packageRules": [
     {
+      "description": "Makefile docker-datasource pins (minlag/mermaid-cli, catthehacker/ubuntu) carry no @sha256 digest. config:best-practices enables docker:pinDigests, which would emit a pinDigest update that collides with and silently suppresses the version bump in the shared custom.regex Makefile manager. Disable digest pinning for these.",
+      "matchFileNames": [
+        "Makefile"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "pinDigests": false
+    },
+    {
       "description": "Wait 3 days before automerging major updates",
       "matchUpdateTypes": [
         "major"


### PR DESCRIPTION
Applies all findings from a full `/project-review` pass (Makefile, CI, Renovate, README, CLAUDE.md, architecture diagram, test coverage). Architecture-diagram review was fully clean.

## Foundation (Phase A)

| Area | Severity | Change |
|------|----------|--------|
| `cleanup-runs.yml` | **BLOCKING** | Exclude open PRs' head SHAs from age-based run deletion (+ `pull-requests: read`). Prevents purging a slow/Renovate PR's run, which removes its `ci-pass` required check and silently blocks the merge. |
| `ci.yml` | HIGH | `build` now `needs: [changes, static-check]` — the 11-leg matrix fast-fails on a lint/trivy/gitleaks failure instead of burning runner minutes. |
| `ci.yml` | HIGH | New standalone `mermaid-lint` job for docs-only (README) edits — a broken Mermaid diagram can no longer merge unvalidated (when code changes, `static-check` already covers it). |
| `renovate.json` | HIGH | `pinDigests:false` for Makefile docker-datasource pins (`minlag/mermaid-cli`, `catthehacker/ubuntu`) — `docker:pinDigests` was emitting a pinDigest update that collided with and suppressed the `custom.regex` version bump. |
| `Makefile` | MEDIUM | Pin `RENOVATE_VERSION` (drop banned `@latest`), tracked by the Makefile custom manager; add `env-check` target. |
| `ci.yml` | MEDIUM/LOW | Sentence-case step names (`Static check`, `Set up mise`); job `timeout-minutes`. |
| `pom.xml` | LOW | Correct stale profile comments — tomcat10 is Servlet 6.1 / Java 17+, tomcat11 is Java 21+. |

## Docs (Phase B)

- **README**: CI badge `?branch=master`; screenshots `800`→`600`; add `env-check` + `mermaid-lint` rows; note build-after-static-check.
- **CLAUDE.md**: add `mermaid-lint` job + build ordering; document static-analysis scope; trim mise/PATH duplication.

## Declined / no-change findings (rationale, so a future review doesn't re-flag)

- **Makefile M1 (no OWASP `cve-check`/`format-check`/`coverage-check`)** — resolved via the documented-rationale option: a 2-servlet demo WAR relies on `trivy-fs` + Renovate for dependency CVEs; the heavier Java gates would add CI secrets and near-zero coverage signal. Documented in CLAUDE.md "Static analysis scope".
- **Makefile `command -v docker` inline in `mermaid-lint`** — sanctioned (matches the skill's canonical target).
- **Makefile `tomcat-install`/`tomcat-switch` lack a `deps` prereq** — declined: the scripts use curl/tar, not mise tools; adding `deps` would force an unnecessary mise install.
- **Renovate `vulnerabilityAlerts` inert / pinned-action lookup** — verify-only (depends on GitHub Dependabot-alerts being enabled; check the Dependency Dashboard on next run). No JSON change.
- **README no `## License` section** — accepted pattern (MIT badge + LICENSE file).

## Test plan

- [x] `make static-check` (lint + trivy-fs + gitleaks + mermaid-lint) — green, no CVEs/leaks
- [x] `make renovate-validate` — no `validationError`
- [x] `actionlint` both workflows — clean
- [x] `mvn -B validate` — OK; `make env-check` — OK
- [ ] CI `ci-pass` green on this PR (build matrix verifies the real per-JDK legs)