### PR TITLE
test: add deployed-WAR smoke test (embedded Jetty) across all profiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,9 +164,38 @@ jobs:
     - name: Lint Mermaid diagrams
       run: make mermaid-lint
 
+  smoke:
+
+    # Deployed-WAR smoke test: boots ROOT.war under embedded Jetty and curls the
+    # real endpoints. Catches the JSP runtime-compile + servlet-forward + deploy
+    # contract (javax vs jakarta) regressions that `mvn package` + unit tests
+    # never exercise (JSPs compile in the container at request time, not at build).
+    needs: [ changes, static-check ]
+    if: ${{ needs.changes.outputs.code == 'true' }}
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    strategy:
+      matrix:
+        maven_profile: [ tomcat9, tomcat10, tomcat11 ]
+
+    steps:
+
+    - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+
+    - name: Set up mise
+      uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+      with:
+        install: true
+        cache: true
+
+    - name: Smoke test
+      run: make smoke PROFILE=${{ matrix.maven_profile }}
+
   ci-pass:
     if: always()
-    needs: [ changes, static-check, build, mermaid-lint ]
+    needs: [ changes, static-check, build, mermaid-lint, smoke ]
     runs-on: ubuntu-latest
     steps:
       - name: Verify all jobs passed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,8 @@ make build PROFILE=tomcat10      # Tomcat 10
 make build PROFILE=tomcat11      # Tomcat 11
 make verify-all                  # compile all profiles
 make jetty-run                   # run locally with Jetty
+make smoke                       # deployed-WAR smoke test via embedded Jetty
+make smoke-all                   # smoke test every profile
 make clean                       # clean build artifacts
 make ci                          # run full local CI pipeline
 make ci-run                      # run GitHub Actions locally via act
@@ -30,7 +32,10 @@ mvn -B package -Ptomcat10        # Tomcat 10 (jakarta.servlet 6.1)
 mvn -B package -Ptomcat11        # Tomcat 11 (jakarta.servlet 6.1)
 ```
 
-Unit tests use **JUnit 5 + Mockito** (run via Surefire). Test sources are profile-specific, mirroring the main sources: `src/test/java` (javax, tomcat9) and `src/test/java-jakarta` (jakarta, tomcat10/11). `make test PROFILE=...` compiles and runs the matching set.
+Two test layers:
+
+- **Unit** — **JUnit 5 + Mockito** (run via Surefire). Test sources are profile-specific, mirroring the main sources: `src/test/java` (javax, tomcat9) and `src/test/java-jakarta` (jakarta, tomcat10/11). `make test PROFILE=...` compiles and runs the matching set.
+- **Deployed-WAR smoke** — `make smoke` / `make smoke-all` (`scripts/smoke.sh`) boots `ROOT.war` under embedded Jetty on an ephemeral port and curls the real endpoints (`/`, `/index.html`, `/index.jsp`, `/infoservlet`), asserting status + body. This exercises what mocks can't: the `index.jsp` scriptlets compiling/running in a real container (JSPs compile at request time, not at `mvn package`), the servlet's `RequestDispatcher` forward, and the per-profile javax/jakarta deploy contract.
 
 ## Maven Profiles
 
@@ -65,6 +70,7 @@ The two `InfoServlet.java` files are identical except for imports (`javax.servle
 
 - `scripts/install-tomcat.sh` — downloads Tomcat 9/10/11 to `~/tomcat/{9,10,11}`, creates `~/tomcat/current` symlink
 - `scripts/deploy.sh` — builds with the correct profile and deploys `ROOT.war` to the target Tomcat
+- `scripts/smoke.sh` — boots `ROOT.war` under embedded Jetty on an ephemeral port and asserts the live endpoints serve (deployed-WAR smoke; `make smoke`)
 
 ## Makefile
 
@@ -80,6 +86,7 @@ GitHub Actions (`ci.yml`) runs on push to `master`, tags `v*`, and pull requests
   - **Tomcat 9**: JDK 11, 17, 18, 21, 25 (Temurin)
   - **Tomcat 10**: JDK 17, 18, 25 (Temurin)
   - **Tomcat 11**: JDK 21, 25 (Temurin)
+- **smoke** — `needs: [changes, static-check]`. Runs `make smoke` per profile (matrix tomcat9/10/11): boots `ROOT.war` under embedded Jetty and curls the real endpoints — catches JSP runtime-compile + deploy-contract regressions the build/unit layer can't.
 - **mermaid-lint** — runs `make mermaid-lint` on docs-only edits (README.md, no code change) so a broken Mermaid diagram can't merge unvalidated; when code changes, `static-check` already covers it.
 - **ci-pass** — aggregator gate; succeeds only if every job passed. It is the single required status check on `master` (enforced via a repository ruleset).
 

--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,17 @@ verify-all: deps
 jetty-run: deps
 	@mvn -B clean package jetty:run -P$(PROFILE)
 
+#smoke: @ Deployed-WAR smoke test via embedded Jetty (use PROFILE=tomcat9|tomcat10|tomcat11)
+smoke: deps
+	@PROFILE=$(PROFILE) ./scripts/smoke.sh
+
+#smoke-all: @ Run the deployed-WAR smoke test for every Tomcat profile
+smoke-all: deps
+	@for p in $(ALLOWED_PROFILES); do \
+		echo "=== smoke $$p ==="; \
+		PROFILE=$$p ./scripts/smoke.sh || exit 1; \
+	done
+
 #deploy: @ Build and deploy ROOT.war to Tomcat (use PROFILE=tomcat9|tomcat10|tomcat11)
 deploy: deps
 	@./scripts/deploy.sh $(subst tomcat,,$(PROFILE))
@@ -191,5 +202,5 @@ env-check:
 	@mise ls --current
 
 .PHONY: help deps clean build test lint trivy-fs gitleaks-scan mermaid-lint static-check \
-	run ci ci-run verify-all jetty-run deploy tomcat-install tomcat-switch \
+	run ci ci-run verify-all jetty-run smoke smoke-all deploy tomcat-install tomcat-switch \
 	deps-print-updates deps-update release renovate-validate env-check

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Run `make help` to see all available targets.
 | `make run` | Run locally with Jetty (alias for jetty-run) |
 | `make jetty-run` | Run locally with embedded Jetty server |
 | `make verify-all` | Verify build compiles for all Tomcat profiles |
+| `make smoke` | Deployed-WAR smoke test via embedded Jetty (use PROFILE=...) — boots `ROOT.war` and curls the real endpoints |
+| `make smoke-all` | Run the deployed-WAR smoke test for every Tomcat profile |
 
 ### Code Quality & Security
 
@@ -244,6 +246,7 @@ GitHub Actions runs on every push to `master`, tags `v*`, and pull requests.
 | **changes** | push (master, tags), PR | Detect whether code paths changed (skips the build on docs-only changes) |
 | **static-check** | when `changes` reports code | `make static-check` — `lint` + `trivy-fs` + `gitleaks-scan` + `mermaid-lint` |
 | **build** | when `changes` reports code (after **static-check**) | `make lint` + `make build` + `make test` across the JDK × Tomcat matrix |
+| **smoke** | when `changes` reports code (after **static-check**) | `make smoke` per profile — boots `ROOT.war` under embedded Jetty and curls the real endpoints (catches JSP runtime-compile + deploy-contract regressions the build/unit layer can't) |
 | **mermaid-lint** | docs-only edits (README.md, no code change) | `make mermaid-lint` — validates the README diagram on doc-only PRs (when code changes, **static-check** already covers it) |
 | **ci-pass** | always | Aggregator gate — succeeds only if every job passed; the single required status check on `master` (repository ruleset) |
 

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#
+# Deployed-WAR smoke test.
+#
+# Builds ROOT.war for a profile, runs it under embedded Jetty on an ephemeral
+# port, and asserts the real endpoints actually serve. This exercises the parts
+# the JUnit/Mockito unit tests cannot reach:
+#   - the index.jsp scriptlets (host/IP/JVM/date, header + cookie enumeration)
+#     compile and run inside a real servlet container,
+#   - InfoServlet's RequestDispatcher forward to index.jsp,
+#   - the per-profile deploy contract (javax.servlet vs jakarta.servlet, context
+#     path "/").
+#
+# Standalone-HTTP-service e2e shape (no k8s / compose): start the process in the
+# background, poll for readiness, curl the endpoints, tear down.
+#
+# Usage: PROFILE=tomcat9|tomcat10|tomcat11 scripts/smoke.sh   (default: tomcat9)
+set -euo pipefail
+
+# --- tunables (env-with-default; see configuration conventions) --------------
+PROFILE="${PROFILE:-tomcat9}"
+SMOKE_HOST="${SMOKE_HOST:-127.0.0.1}"
+READY_TIMEOUT_SECONDS="${READY_TIMEOUT_SECONDS:-120}"
+POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-2}"
+CURL_MAX_TIME_SECONDS="${CURL_MAX_TIME_SECONDS:-5}"
+
+# Ephemeral host port — kernel-allocated via bind(:0), never a literal, so
+# parallel runs / `make jetty-run` / side-by-side dev don't collide.
+pick_port() {
+  python3 -c 'import socket; s=socket.socket(); s.bind(("",0)); print(s.getsockname()[1]); s.close()'
+}
+SMOKE_PORT="${SMOKE_PORT:-$(pick_port)}"
+BASE="http://${SMOKE_HOST}:${SMOKE_PORT}"
+
+# All three profiles' Jetty Maven plugins declare goalPrefix `jetty` (the
+# tomcat9/tomcat10 org.eclipse.jetty:jetty-maven-plugin AND the tomcat11
+# Jetty 12 org.eclipse.jetty.ee10:jetty-ee10-maven-plugin — verified from its
+# plugin.xml), so `jetty:run` resolves to the profile's declared plugin. This
+# matches `make jetty-run`.
+case "$PROFILE" in
+  tomcat9 | tomcat10 | tomcat11) JETTY_GOAL="jetty:run" ;;
+  *) echo "ERROR: unknown PROFILE=$PROFILE (expected tomcat9|tomcat10|tomcat11)"; exit 2 ;;
+esac
+
+LOG="$(mktemp -t smoke-jetty.XXXXXX.log)"
+JETTY_PID=""
+PASS=0
+FAIL=0
+
+cleanup() {
+  if [ -n "$JETTY_PID" ]; then
+    # JETTY_PID is a setsid group leader, so its PGID == JETTY_PID — kill the
+    # whole group (the mvn wrapper AND the forked Jetty JVM).
+    kill -TERM "-$JETTY_PID" 2>/dev/null || kill -TERM "$JETTY_PID" 2>/dev/null || true
+    wait "$JETTY_PID" 2>/dev/null || true
+  fi
+  rm -f "$LOG"
+}
+trap cleanup EXIT
+
+echo "==> Smoke: PROFILE=$PROFILE  goal=$JETTY_GOAL  $BASE"
+
+# Start Jetty in its own process group so cleanup can kill the whole tree.
+setsid mvn -B clean package "$JETTY_GOAL" \
+  -P"$PROFILE" \
+  -Djetty.http.port="$SMOKE_PORT" \
+  -Djetty.http.host="$SMOKE_HOST" \
+  > "$LOG" 2>&1 &
+JETTY_PID=$!
+
+# --- readiness poll -----------------------------------------------------------
+echo "==> Waiting up to ${READY_TIMEOUT_SECONDS}s for $BASE/ to serve..."
+ready=""
+deadline=$((SECONDS + READY_TIMEOUT_SECONDS))
+while [ "$SECONDS" -lt "$deadline" ]; do
+  if ! kill -0 "$JETTY_PID" 2>/dev/null; then
+    echo "ERROR: Jetty process exited before becoming ready. Last 40 log lines:"
+    tail -40 "$LOG" | sed 's/^/    /'
+    exit 1
+  fi
+  if curl -sf -o /dev/null --max-time "$CURL_MAX_TIME_SECONDS" "$BASE/"; then
+    ready=yes
+    break
+  fi
+  sleep "$POLL_INTERVAL_SECONDS"
+done
+if [ "$ready" != yes ]; then
+  echo "ERROR: $BASE/ did not become ready within ${READY_TIMEOUT_SECONDS}s. Last 40 log lines:"
+  tail -40 "$LOG" | sed 's/^/    /'
+  exit 1
+fi
+echo "==> Ready."
+
+# --- assertions ---------------------------------------------------------------
+# Single curl per check captures BOTH the HTTP status and the body, so the body
+# asserted-on is the body of the asserted-status response (see test-coverage
+# conventions: status + body, never body-only).
+check() {
+  local name="$1" path="$2" want_status="$3" want_body="$4"
+  local tmp status body
+  tmp="$(mktemp)"
+  status="$(curl -s -o "$tmp" -w '%{http_code}' --max-time "$CURL_MAX_TIME_SECONDS" "$BASE$path" 2>/dev/null || true)"
+  body="$(cat "$tmp")"; rm -f "$tmp"
+  if [ "$status" = "$want_status" ] && printf '%s' "$body" | grep -qF "$want_body"; then
+    echo "  PASS: $name (GET $path -> HTTP $status, body contains '$want_body')"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name (GET $path)"
+    echo "        expected: HTTP $want_status, body contains '$want_body'"
+    echo "        actual:   HTTP $status, body[:200]: $(printf '%s' "$body" | head -c 200 | tr '\n' ' ')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Content-Type assertion (servlet sets text/html;charset=UTF-8 explicitly).
+check_content_type() {
+  local name="$1" path="$2" want_ct="$3" ct
+  ct="$(curl -sI --max-time "$CURL_MAX_TIME_SECONDS" "$BASE$path" 2>/dev/null \
+        | awk 'tolower($1)=="content-type:"{sub(/^[^:]*:[ \t]*/,""); print; exit}' | tr -d '\r')"
+  if printf '%s' "$ct" | grep -qiF "$want_ct"; then
+    echo "  PASS: $name (Content-Type '$ct' contains '$want_ct')"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name (GET $path Content-Type = '$ct', expected ~'$want_ct')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "==> Asserting endpoints..."
+# Welcome page at context root "/" (replaces Tomcat's default ROOT app).
+check "root welcome page"        "/"            200 "Java Web Application"
+check "static index.html"        "/index.html"  200 "Java Web Application"
+# JSP scriptlets render (host/IP/JVM + header/cookie tables) — untested by mocks.
+check "index.jsp renders"        "/index.jsp"   200 "Server Info"
+check "index.jsp header table"   "/index.jsp"   200 "HTTP Request Headers Received"
+# Servlet forwards to index.jsp via RequestDispatcher.
+check "InfoServlet forward"      "/infoservlet" 200 "Server Info"
+check_content_type "InfoServlet content-type" "/infoservlet" "text/html"
+
+echo "==> Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Implements the integration/e2e gap from the `/project-review` test-coverage analysis (the one genuine MEDIUM finding).

## Why

The JUnit + Mockito unit tests cover `InfoServlet`'s forward logic, but **nothing exercises the real served output**:
- `index.jsp`'s Java scriptlets (host/IP/JVM, header + cookie enumeration) compile and run **only in a servlet container, at request time** — never at `mvn package`. A JSP compile error or NPE ships green through the entire build + unit-test matrix.
- The per-profile **javax vs jakarta deploy contract** + context path `/` is invisible to in-process mocks.

## What

| File | Change |
|------|--------|
| `scripts/smoke.sh` | Boots `ROOT.war` under embedded Jetty on a **kernel-allocated ephemeral port** (no literal — parallel-safe), polls for readiness, asserts **status + body** on `/`, `/index.html`, `/index.jsp`, `/infoservlet` (+ servlet `Content-Type`), and tears down its process group. All tunables are env-with-default; `shellcheck`-clean; committed `100755`. |
| `Makefile` | `make smoke` (PROFILE-param) + `make smoke-all` (every profile). |
| `ci.yml` | `smoke` matrix job (`tomcat9`/`tomcat10`/`tomcat11`), `needs: [changes, static-check]`, added to `ci-pass`. Parallel matrix → ~no wall-clock penalty. |
| `README.md` / `CLAUDE.md` | Document the targets, the new CI job, and the two test layers (unit + deployed-WAR smoke). |

## Verified locally

`make smoke` passes **6/6 on tomcat9, tomcat10, and tomcat11**. The Jetty 12 `jetty-ee10-maven-plugin` (tomcat11) declares `goalPrefix=jetty` — confirmed from its `plugin.xml` — so `jetty:run` resolves for all three profiles (matches `make jetty-run`).

## Test plan

- [x] `make smoke PROFILE=tomcat9|tomcat10|tomcat11` — 6/6 each
- [x] `actionlint` + `shellcheck scripts/smoke.sh` — clean
- [x] Phase 4 post-scaffold hardcode audit — no unguarded literals
- [ ] CI `ci-pass` green (the new `smoke` matrix runs the WAR for real per profile)