### PR TITLE
fix(makefile): guard release target against pre-existing tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,8 @@ deps-update: deps-print-updates
 release:
 	@bash -c 'read -p "New tag (current: $(CURRENTTAG)): " newtag && \
 		echo "$$newtag" | grep -qE "^v[0-9]+\.[0-9]+\.[0-9]+$$" || { echo "Error: Tag must match vN.N.N"; exit 1; } && \
+		{ ! git rev-parse -q --verify "refs/tags/$$newtag" >/dev/null 2>&1 || { echo "ERROR: tag $$newtag already exists locally. Pick a new version or delete it: git tag -d $$newtag"; exit 1; }; } && \
+		{ ! git ls-remote --exit-code --tags origin "refs/tags/$$newtag" >/dev/null 2>&1 || { echo "ERROR: tag $$newtag already exists on origin. Pick a new version."; exit 1; }; } && \
 		echo -n "Create and push $$newtag? [y/N] " && read ans && [ "$${ans:-N}" = y ] && \
 		echo $$newtag > ./version.txt && \
 		git add -A && \


### PR DESCRIPTION
The `release` recipe wrote `version.txt`, `git add -A`, and `git commit` **before** `git tag`, with no check that the tag doesn't already exist. Re-running with an existing tag lands the release commit but aborts at `git tag`, leaving a dangling commit and a half-published release.

**Fix (Safety Check #16):** add local (`git rev-parse --verify`) + remote (`git ls-remote`) tag pre-existence guards after the semver validation, before the confirm prompt and any mutation.

Verified: `make -n release` shows the guards precede `git commit`/`git tag`; exercising the guard chain against a temporary local `v0.0.99` tag errors (exit 1) before the confirm (temp tag deleted, never pushed), tree stays clean.